### PR TITLE
fix(security): upgrade cryptography and requests to patch CVEs (closes #8, closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.2] — 2026-04-03
+
+### Security
+- Upgrade `cryptography` minimum to `>=46.0.6` to patch 6 known CVEs including memory corruption (PYSEC-2024-225, GHSA-3ww4-gg4f-jr7f, GHSA-9v9h-cgj8-h64p, GHSA-h4gh-qq45-vh27, GHSA-r6ph-v2qm-q3c2, GHSA-m959-cc7f-wv43)
+- Upgrade `requests` minimum to `>=2.32.6` to patch CVE in requests 2.32.5
+
 ## [1.5.1] — 2026-03-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27",
+    "cryptography>=46.0.6",
+    "requests>=2.32.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
## What changed\n\n- Upgraded `cryptography` to `>=46.0.6` to patch 6 known CVEs including memory corruption (PYSEC-2024-225, GHSA-3ww4-gg4f-jr7f, GHSA-9v9h-cgj8-h64p, GHSA-h4gh-qq45-vh27, GHSA-r6ph-v2qm-q3c2, GHSA-m959-cc7f-wv43)\n- Upgraded `requests` to `>=2.32.6` to patch GHSA-gc5v-m9x4-r6x2\n- Updated CHANGELOG.md\n\ncloses #8\ncloses #9