### PR TITLE
fix(compat): handle 204 No Content, fix intervalSeconds, add camelCase parse (closes #62, closes #64, closes #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - **#42** `WebhookEvent` class: event value strings converted from `SCREAMING_SNAKE_CASE` to `dot.notation` (e.g. `ORDER_FILLED = "order.filled"`) to match platform webhook registration contract
 - **#39** `create_strategy_from_description()`: request body field renamed `description` → `query` to match platform endpoint (affects both sync and async clients)
 - **#40** `start_strategy()`: mode value is now uppercased before sending (`mode.upper()`) so that default `"paper"` and user-supplied `"live"` are sent as `"PAPER"` / `"LIVE"` as required by the platform enum (affects both sync and async clients)
+- **BREAKING** `_delete()`: handle 204 No Content responses — `delete_strategy()` no longer raises `JSONDecodeError` (closes #71)
+- **BREAKING** `place_smart_order()`: rename `interval_minutes` parameter to `interval_seconds` and send `intervalSeconds` in request body to match platform contract — TWAP/DCA orders were executing 60x too fast (closes #64)
+- **BREAKING** `_parse()`: add `_camel_to_snake()` mapping so camelCase API fields (`baseToken`, `volume24h`, `createdAt`, etc.) correctly populate snake_case dataclass fields — all multi-word response fields were silently defaulting (closes #62)
 
 ## [1.5.2] — 2026-04-03
 

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import json as _json
 import logging as _log
+import re
 import socket
 from dataclasses import fields
 from typing import Any, AsyncIterator, Iterator, TypeVar, get_type_hints
@@ -77,16 +78,24 @@ _MODEL_REGISTRY: dict[str, type] = {
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _camel_to_snake(name: str) -> str:
+    """Convert camelCase to snake_case (e.g. 'baseToken' -> 'base_token')."""
+    return re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", name).lower()
+
+
 def _parse(cls: type[T], data: dict[str, Any]) -> T:
     """Recursively instantiate a dataclass from a JSON dict."""
     if not isinstance(data, dict):
         return data  # type: ignore[return-value]
 
+    # Build a snake_case lookup so camelCase API keys map to dataclass fields
+    snake_data = {_camel_to_snake(k): v for k, v in data.items()}
+
     hints = get_type_hints(cls)
     kwargs: dict[str, Any] = {}
 
     for f in fields(cls):  # type: ignore[arg-type]
-        raw = data.get(f.name)
+        raw = data.get(f.name) or snake_data.get(f.name)
         if raw is None:
             continue
 
@@ -272,6 +281,8 @@ class PolyforgeClient:
     def _delete(self, path: str) -> Any:
         resp = self._client.delete(path)
         _raise_for_status(resp)
+        if resp.status_code == 204:
+            return None
         return resp.json()
 
     # -- Markets --
@@ -519,7 +530,7 @@ class PolyforgeClient:
         outcome: str,
         total_size: float,
         slices: int | None = None,
-        interval_minutes: int | None = None,
+        interval_seconds: int | None = None,
         limit_price: float | None = None,
         entry_price: float | None = None,
         take_profit_price: float | None = None,
@@ -536,7 +547,7 @@ class PolyforgeClient:
             "totalSize": total_size,
         }
         if slices is not None: body["slices"] = slices
-        if interval_minutes is not None: body["intervalMinutes"] = interval_minutes
+        if interval_seconds is not None: body["intervalSeconds"] = interval_seconds
         if limit_price is not None: body["limitPrice"] = limit_price
         if entry_price is not None: body["entryPrice"] = entry_price
         if take_profit_price is not None: body["takeProfitPrice"] = take_profit_price
@@ -821,6 +832,8 @@ class AsyncPolyforgeClient:
     async def _delete(self, path: str) -> Any:
         resp = await self._client.delete(path)
         _raise_for_status(resp)
+        if resp.status_code == 204:
+            return None
         return resp.json()
 
     # -- Markets --
@@ -1064,7 +1077,7 @@ class AsyncPolyforgeClient:
         outcome: str,
         total_size: float,
         slices: int | None = None,
-        interval_minutes: int | None = None,
+        interval_seconds: int | None = None,
         limit_price: float | None = None,
         entry_price: float | None = None,
         take_profit_price: float | None = None,
@@ -1081,7 +1094,7 @@ class AsyncPolyforgeClient:
             "totalSize": total_size,
         }
         if slices is not None: body["slices"] = slices
-        if interval_minutes is not None: body["intervalMinutes"] = interval_minutes
+        if interval_seconds is not None: body["intervalSeconds"] = interval_seconds
         if limit_price is not None: body["limitPrice"] = limit_price
         if entry_price is not None: body["entryPrice"] = entry_price
         if take_profit_price is not None: body["takeProfitPrice"] = take_profit_price


### PR DESCRIPTION
## What changed

- **#71 — 204 No Content crash**: `_delete()` (sync + async) now returns `None` on 204 instead of crashing with `JSONDecodeError`. Fixes `delete_strategy()`.
- **#64 — intervalMinutes → intervalSeconds**: `place_smart_order()` parameter renamed from `interval_minutes` to `interval_seconds` and JSON key changed from `intervalMinutes` to `intervalSeconds` to match platform contract. TWAP/DCA orders were executing 60x too fast.
- **#62 — _parse camelCase mapping**: Added `_camel_to_snake()` helper so the `_parse()` function correctly maps camelCase API keys (e.g. `baseToken`, `volume24h`, `createdAt`) to snake_case dataclass fields. All multi-word response fields were silently defaulting.

## Quality gates

- Python syntax check ✅
- Import + signature verification ✅
- `_camel_to_snake()` unit assertions ✅

closes #62
closes #64
closes #71