### PR TITLE
fix(ci): harden CI runners and replace shell: node with bash (closes #67, closes #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Lint & Test
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -25,11 +28,9 @@ jobs:
         continue-on-error: true
 
       - name: Test
-        shell: node {0}
         run: |
-          const fs = require('fs');
-          if (fs.existsSync('tests') && fs.readdirSync('tests').some(f => f.endsWith('.py'))) {
-            require('child_process').execSync('pip install pytest && pytest tests/ -v', { stdio: 'inherit' });
-          } else {
-            console.log('No test files found — skipping');
-          }
+          if [ -d tests ] && ls tests/*.py 1>/dev/null 2>&1; then
+            pip install pytest && pytest tests/ -v
+          else
+            echo "No test files found — skipping"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.3] — 2026-04-08
+
+### Security
+- Switch CI from self-hosted to GitHub-hosted runners (`ubuntu-latest`) and add `permissions: contents: read` to prevent arbitrary code execution from fork PRs (closes #68)
+- Replace `shell: node {0}` in CI test step with bash to eliminate arbitrary code execution vector (closes #67)
+
 ## [1.5.2] — 2026-04-03
 
 ### Fixed


### PR DESCRIPTION
## What changed

1. Switched CI from self-hosted to GitHub-hosted runners (`ubuntu-latest`) and added `permissions: contents: read` to prevent arbitrary code execution from fork PRs
2. Replaced `shell: node {0}` in test step with standard bash to eliminate arbitrary code execution vector

closes #67
closes #68

https://claude.ai/code/session_01GZ1NC22HTna9vjx2GSxTff