### PR TITLE
fix(ci): use ubuntu-latest runner for pull_request events (closes #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Lint & Test
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #68)
+
 ## [1.5.2] — 2026-04-03
 
 ### Fixed


### PR DESCRIPTION
## What changed
- Switch CI from self-hosted runner to ubuntu-latest for pull_request events to prevent arbitrary code execution from fork PRs
- Add permissions: contents: read to restrict GITHUB_TOKEN scope

closes #68