### PR TITLE
fix(security): redact API key, production default URL, fix README (closes #37, closes #47, closes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Security
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #68)
+- **`__repr__`**: fully redact API key in both `PolyforgeClient` and `AsyncPolyforgeClient` — previously leaked first 6 characters which is sufficient to identify keys with known prefix formats (closes #37)
+- **Default URL**: change default `api_url` from `https://localhost:3002` to `https://api.polyforge.app` — localhost with HTTPS causes TLS failures that encourage insecure workarounds (closes #47)
+- **README**: fix documented default URL from `http://localhost:3002` to `https://api.polyforge.app` to match code (closes #78)
+- **Webhook SSRF**: add `.local` mDNS hostname blocking to `_validate_webhook_url` (hardens existing #38 fix)
 
 ### Fixed
 - **#48** `ai_query()`: request body field renamed `query` → `question` to match platform `AiQueryDto` (affects both sync and async clients)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ asyncio.run(main())
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `api_key` | *required* | Your Polyforge API key |
-| `api_url` | `http://localhost:3002` | Base URL of the Polyforge API |
+| `api_url` | `https://api.polyforge.app` | Base URL of the Polyforge API |
 | `timeout` | `15.0` | Request timeout in seconds |
 
 ## API Reference

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -185,7 +185,8 @@ def _validate_webhook_url(url: str) -> None:
         raise ValueError("Webhook URL must contain a valid hostname")
 
     # --- blocked hostname check ---
-    if hostname.lower() in _BLOCKED_HOSTNAMES:
+    lower_hostname = hostname.lower()
+    if lower_hostname in _BLOCKED_HOSTNAMES or lower_hostname.endswith(".local"):
         raise ValueError("Webhook URL cannot point to localhost or internal addresses")
 
     # --- resolve hostname and validate each resulting IP ---
@@ -235,7 +236,7 @@ class PolyforgeClient:
     def __init__(
         self,
         api_key: str,
-        api_url: str = "https://localhost:3002",
+        api_url: str = "https://api.polyforge.app",
         timeout: float = 15.0,
     ) -> None:
         self._api_key = api_key
@@ -258,8 +259,7 @@ class PolyforgeClient:
         )
 
     def __repr__(self) -> str:
-        masked = self._api_key[:6] + "***" if len(self._api_key) > 6 else "***"
-        return f"PolyforgeClient(api_key='{masked}', base_url='{self._api_url}')"
+        return f"PolyforgeClient(api_key='[REDACTED]', base_url='{self._api_url}')"
 
     # -- helpers --
 
@@ -786,7 +786,7 @@ class AsyncPolyforgeClient:
     def __init__(
         self,
         api_key: str,
-        api_url: str = "https://localhost:3002",
+        api_url: str = "https://api.polyforge.app",
         timeout: float = 15.0,
     ) -> None:
         self._api_key = api_key
@@ -809,8 +809,7 @@ class AsyncPolyforgeClient:
         )
 
     def __repr__(self) -> str:
-        masked = self._api_key[:6] + "***" if len(self._api_key) > 6 else "***"
-        return f"AsyncPolyforgeClient(api_key='{masked}', base_url='{self._api_url}')"
+        return f"AsyncPolyforgeClient(api_key='[REDACTED]', base_url='{self._api_url}')"
 
     # -- helpers --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 """Basic smoke tests for PolyforgeClient."""
 
 import pytest
-from polyforge.client import PolyforgeClient, AsyncPolyforgeClient
+from polyforge.client import PolyforgeClient, AsyncPolyforgeClient, _validate_webhook_url
 from polyforge.errors import (
     PolyforgeError,
     AuthenticationError,
@@ -248,6 +248,46 @@ class TestModelParsing:
         assert strategy.pnl == 0.0
         assert strategy.win_rate == 0.0
         assert strategy.total_trades == 0
+
+
+class TestReprSecurity:
+    """Test that __repr__ does not leak API key material."""
+
+    def test_sync_client_repr_redacts_api_key(self):
+        """Should fully redact API key in sync client __repr__."""
+        client = PolyforgeClient(api_key="pf_live_supersecretkey123456")
+        repr_str = repr(client)
+        assert "supersecret" not in repr_str
+        assert "pf_live" not in repr_str
+        assert "[REDACTED]" in repr_str
+        client.close()
+
+    def test_async_client_repr_redacts_api_key(self):
+        """Should fully redact API key in async client __repr__."""
+        client = AsyncPolyforgeClient(api_key="pf_live_supersecretkey123456")
+        repr_str = repr(client)
+        assert "supersecret" not in repr_str
+        assert "pf_live" not in repr_str
+        assert "[REDACTED]" in repr_str
+
+
+class TestWebhookValidation:
+    """Test webhook URL SSRF validation."""
+
+    def test_rejects_dot_local_hostname(self):
+        """Should reject .local hostnames to prevent mDNS SSRF."""
+        with pytest.raises(ValueError, match="internal addresses"):
+            _validate_webhook_url("https://myservice.local/hook")
+
+    def test_rejects_http_scheme(self):
+        """Should reject non-HTTPS webhook URLs."""
+        with pytest.raises(ValueError, match="HTTPS"):
+            _validate_webhook_url("http://example.com/hook")
+
+    def test_rejects_localhost(self):
+        """Should reject localhost webhook URLs."""
+        with pytest.raises(ValueError, match="internal addresses"):
+            _validate_webhook_url("https://localhost/hook")
 
 
 class TestContextManagers:


### PR DESCRIPTION
## Summary

Batched security fixes for 3 MEDIUM issues:

- **#37**: `__repr__` leaked first 6 characters of API key in logs/tracebacks — now fully redacted as `[REDACTED]`, matching Rust and TypeScript SDK behavior
- **#47**: Default `api_url` changed from `https://localhost:3002` to `https://api.polyforge.app` — localhost HTTPS causes TLS failures encouraging insecure workarounds
- **#78**: README documented `http://localhost:3002` while code used `https://` — now both point to `https://api.polyforge.app`

Also hardens webhook SSRF validation by blocking `.local` mDNS hostnames.

## What Changed

| File | Change |
|------|--------|
| `src/polyforge/client.py` | Remove 6-char API key prefix from `__repr__`, change default URL, add `.local` blocking |
| `README.md` | Fix documented default URL |
| `tests/test_client.py` | Add 5 new security tests |
| `CHANGELOG.md` | Document all changes |

## Tests Added

- `test_sync_client_repr_redacts_api_key`
- `test_async_client_repr_redacts_api_key`
- `test_rejects_dot_local_hostname`
- `test_rejects_http_scheme`
- `test_rejects_localhost`

All 31 tests pass.

closes #37, closes #47, closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)