### PR TITLE
fix(compat): revert intervalSeconds back to intervalMinutes in place_smart_order (closes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #68)
 
 ### Fixed
+- **BREAKING** `place_smart_order()`: revert `interval_seconds`/`intervalSeconds` back to `interval_minutes`/`intervalMinutes` — the #64 fix was based on incorrect platform contract info; platform DTO uses `intervalMinutes` (closes #79)
 - **#48** `ai_query()`: request body field renamed `query` → `question` to match platform `AiQueryDto` (affects both sync and async clients)
 - **#49** `run_backtest()`: request body fields renamed `startDate` → `dateRangeStart` and `endDate` → `dateRangeEnd`; removed non-whitelisted `initialBalance` field; added `quickMode`, `strategyBlocks`, `marketBindings` optional parameters (affects both sync and async clients)
 - **#42** `WebhookEvent` class: event value strings converted from `SCREAMING_SNAKE_CASE` to `dot.notation` (e.g. `ORDER_FILLED = "order.filled"`) to match platform webhook registration contract

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -530,7 +530,7 @@ class PolyforgeClient:
         outcome: str,
         total_size: float,
         slices: int | None = None,
-        interval_seconds: int | None = None,
+        interval_minutes: int | None = None,
         limit_price: float | None = None,
         entry_price: float | None = None,
         take_profit_price: float | None = None,
@@ -547,7 +547,7 @@ class PolyforgeClient:
             "totalSize": total_size,
         }
         if slices is not None: body["slices"] = slices
-        if interval_seconds is not None: body["intervalSeconds"] = interval_seconds
+        if interval_minutes is not None: body["intervalMinutes"] = interval_minutes
         if limit_price is not None: body["limitPrice"] = limit_price
         if entry_price is not None: body["entryPrice"] = entry_price
         if take_profit_price is not None: body["takeProfitPrice"] = take_profit_price
@@ -1077,7 +1077,7 @@ class AsyncPolyforgeClient:
         outcome: str,
         total_size: float,
         slices: int | None = None,
-        interval_seconds: int | None = None,
+        interval_minutes: int | None = None,
         limit_price: float | None = None,
         entry_price: float | None = None,
         take_profit_price: float | None = None,
@@ -1094,7 +1094,7 @@ class AsyncPolyforgeClient:
             "totalSize": total_size,
         }
         if slices is not None: body["slices"] = slices
-        if interval_seconds is not None: body["intervalSeconds"] = interval_seconds
+        if interval_minutes is not None: body["intervalMinutes"] = interval_minutes
         if limit_price is not None: body["limitPrice"] = limit_price
         if entry_price is not None: body["entryPrice"] = entry_price
         if take_profit_price is not None: body["takeProfitPrice"] = take_profit_price


### PR DESCRIPTION
## Summary

- **#79**: `place_smart_order()` was sending `intervalSeconds` but platform expects `intervalMinutes`
- This is a regression from #64 which incorrectly renamed the field
- TWAP/DCA orders were silently losing their interval config (NestJS `whitelist: true` strips the unknown `intervalSeconds` field)

## What Changed

| File | Change |
|------|--------|
| `src/polyforge/client.py` | Renamed `interval_seconds` param back to `interval_minutes`, sends `intervalMinutes` in body (both sync + async) |
| `CHANGELOG.md` | Documented the revert |

## Verification

- Confirmed platform DTO uses `intervalMinutes` via `services/api-service/src/orders/dto/place-smart-order.dto.ts:51`
- TS SDK already correctly uses `intervalMinutes` (`src/types.ts:329`)

closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)