### PR TITLE
fix(deps): upgrade setuptools and wheel in CI to fix CVEs (closes #70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           python-version: '3.12'
           cache: pip
 
+      - name: Upgrade build toolchain
+        run: pip install --upgrade "setuptools>=78.1.1" "wheel>=0.46.2" pip
+
       - name: Install dependencies
         run: pip install -e ".[dev]" || pip install -e .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Security
+- **deps**: upgrade `setuptools>=78.1.1` and `wheel>=0.46.2` in CI before `pip install` — fixes PYSEC-2025-49 (path traversal/RCE), GHSA-cx63-2mw6-8hw5 (RCE via `package_index`), GHSA-8rrh-rw8j-w5fx (path traversal in `wheel.cli.unpack`) (closes #70)
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #68)
 - **`__repr__`**: fully redact API key in both `PolyforgeClient` and `AsyncPolyforgeClient` — previously leaked first 6 characters which is sufficient to identify keys with known prefix formats (closes #37)
 - **Default URL**: change default `api_url` from `https://localhost:3002` to `https://api.polyforge.app` — localhost with HTTPS causes TLS failures that encourage insecure workarounds (closes #47)


### PR DESCRIPTION
## Summary
- Add `pip install --upgrade setuptools>=78.1.1 wheel>=0.46.2` step in CI before installing dependencies
- Fixes 3 CVEs: PYSEC-2025-49, GHSA-cx63-2mw6-8hw5 (setuptools RCE/path traversal), GHSA-8rrh-rw8j-w5fx (wheel path traversal)

## Test plan
- [x] All 31 tests pass locally
- [ ] CI runs on PR (ubuntu-latest will use updated packages)

closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)