### PR TITLE
fix(security): remove unused cryptography and requests dependencies (closes #46, closes #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Removed
+- **deps**: remove unused `cryptography` and `requests` from runtime dependencies — neither is imported anywhere in the SDK; `httpx` is the sole HTTP client; removing them reduces attack surface and transitive dependency count (closes #46, closes #35)
+
 ### Security
 - **Webhook SSRF (TOCTOU)**: refactor `_validate_webhook_url` to eliminate DNS rebinding race condition (CWE-367) — extracted `_is_ip_blocked()` and `_resolve_and_validate_ips()` helpers, now returns resolved IPs for audit logging, documented server-side validation requirement (closes #69)
 - **deps**: upgrade `setuptools>=78.1.1` and `wheel>=0.46.2` in CI before `pip install` — fixes PYSEC-2025-49 (path traversal/RCE), GHSA-cx63-2mw6-8hw5 (RCE via `package_index`), GHSA-8rrh-rw8j-w5fx (path traversal in `wheel.cli.unpack`) (closes #70)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27",
-    "cryptography>=46.0.6",
-    "requests>=2.32.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- **Problem**: `cryptography` and `requests` are declared as runtime dependencies in `pyproject.toml` but neither is imported anywhere in the SDK source code. The SDK uses `httpx` exclusively for HTTP. These unused dependencies increase the install footprint and attack surface — `cryptography` alone has had 6+ CVEs patched in recent versions, and `requests` pulls in `urllib3`, `certifi`, `charset-normalizer`, and `idna` as transitive deps.
- **Fix**: Removed both `cryptography>=46.0.6` and `requests>=2.32.6` from `[project].dependencies`, leaving only `httpx>=0.27`.
- **Verification**: `grep -r` across the entire repository confirms zero imports of either library. All 42 existing tests pass. Editable install (`pip install -e .`) succeeds cleanly.

## What changed

- `pyproject.toml`: removed `cryptography` and `requests` from dependencies
- `CHANGELOG.md`: added removal note under `[Unreleased] > Removed`

## Test plan

- [x] Verified neither `cryptography` nor `requests` is imported anywhere in `src/` or `tests/`
- [x] `pip install -e .` succeeds
- [x] `pytest` — 42/42 tests pass
- [x] No source code modified — only dependency metadata and changelog

Closes #46, closes #35

Co-Authored-By: R0b1n (Claude Code @ polyforge-lab) <noreply@anthropic.com>