### PR TITLE
fix(compat): correct 4 breaking request payload regressions (closes #89, #90, #91, #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.8] — 2026-04-13
+
+### Fixed
+- **BREAKING** `ai_query()`: send `{ "query" }` instead of `{ "question" }` to match platform `AiQueryDto` — AI queries were returning HTTP 400 (closes #89, regression of #48)
+- **BREAKING** `create_strategy_from_description()`: send `{ "description" }` instead of `{ "query" }` to match platform `CreateFromDescriptionDto` — AI strategy creation was returning HTTP 400 (closes #90, regression of #39)
+- **BREAKING** `WebhookEvent`: change values from dot.notation (`order.filled`) to SCREAMING_SNAKE_CASE (`ORDER_FILLED`) to match platform `CreateWebhookDto` validation — webhook creation was returning HTTP 400 (closes #91, regression of #42)
+- **BREAKING** `start_strategy()`: send lowercase `mode` (`"live"`, `"paper"`) instead of uppercased — strategy start was returning HTTP 400 (closes #92, regression of #40)
+
 ## [Unreleased]
 
 ### Security

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -389,13 +389,13 @@ class PolyforgeClient:
         return _parse(Strategy, self._post("/api/v1/strategies", json=body))
 
     def create_strategy_from_description(self, description: str, market_id: str | None = None) -> Strategy:
-        body: dict[str, Any] = {"query": description}
+        body: dict[str, Any] = {"description": description}
         if market_id is not None:
             body["marketId"] = market_id
         return _parse(Strategy, self._post("/api/v1/strategies/from-description", json=body))
 
     def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
-        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode.upper()}))
+        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))
@@ -748,7 +748,7 @@ class PolyforgeClient:
     # -- AI --
 
     def ai_query(self, query: str) -> AiQueryResponse:
-        return _parse(AiQueryResponse, self._post("/api/v1/ai/query", json={"question": query}))
+        return _parse(AiQueryResponse, self._post("/api/v1/ai/query", json={"query": query}))
 
     # -- Accuracy & Portfolio Review --
 
@@ -940,13 +940,13 @@ class AsyncPolyforgeClient:
         return _parse(Strategy, await self._post("/api/v1/strategies", json=body))
 
     async def create_strategy_from_description(self, description: str, market_id: str | None = None) -> Strategy:
-        body: dict[str, Any] = {"query": description}
+        body: dict[str, Any] = {"description": description}
         if market_id is not None:
             body["marketId"] = market_id
         return _parse(Strategy, await self._post("/api/v1/strategies/from-description", json=body))
 
     async def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
-        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode.upper()}))
+        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     async def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))
@@ -1292,7 +1292,7 @@ class AsyncPolyforgeClient:
     # -- AI --
 
     async def ai_query(self, query: str) -> AiQueryResponse:
-        return _parse(AiQueryResponse, await self._post("/api/v1/ai/query", json={"question": query}))
+        return _parse(AiQueryResponse, await self._post("/api/v1/ai/query", json={"query": query}))
 
     # -- Accuracy & Portfolio Review --
 

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -247,21 +247,21 @@ class CopyConfig:
 
 
 class WebhookEvent:
-    """Constants for webhook event names (dot.notation as expected by the platform).
+    """Constants for webhook event names (SCREAMING_SNAKE_CASE as expected by the platform).
 
     Usage::
 
         client.create_webhook(url="https://...", events=[WebhookEvent.ORDER_FILLED])
     """
 
-    ORDER_FILLED = "order.filled"
-    ORDER_PLACED = "order.placed"
-    ORDER_CANCELLED = "order.cancelled"
-    STRATEGY_STARTED = "strategy.started"
-    STRATEGY_STOPPED = "strategy.stopped"
-    STRATEGY_ERROR = "strategy.error"
-    BACKTEST_COMPLETED = "backtest.completed"
-    BACKTEST_FAILED = "backtest.failed"
+    ORDER_FILLED = "ORDER_FILLED"
+    ORDER_PLACED = "ORDER_PLACED"
+    ORDER_CANCELLED = "ORDER_CANCELLED"
+    STRATEGY_STARTED = "STRATEGY_STARTED"
+    STRATEGY_STOPPED = "STRATEGY_STOPPED"
+    STRATEGY_ERROR = "STRATEGY_ERROR"
+    BACKTEST_COMPLETED = "BACKTEST_COMPLETED"
+    BACKTEST_FAILED = "BACKTEST_FAILED"
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ from polyforge.errors import (
     RateLimitError,
     ServerError,
 )
-from polyforge.models import Market, Strategy, Portfolio
+from polyforge.models import Market, Strategy, Portfolio, WebhookEvent
 
 
 class TestClientInstantiation:
@@ -396,3 +396,45 @@ class TestContextManagers:
                 assert client is not None
 
         asyncio.run(test())
+
+
+class TestPlatformContractCompliance:
+    """Regression tests for platform DTO field name compliance (#89-#92)."""
+
+    def test_webhook_event_values_are_screaming_snake_case(self):
+        """WebhookEvent values must use SCREAMING_SNAKE_CASE, not dot.notation (#91)."""
+        events = [
+            WebhookEvent.ORDER_FILLED,
+            WebhookEvent.ORDER_PLACED,
+            WebhookEvent.ORDER_CANCELLED,
+            WebhookEvent.STRATEGY_STARTED,
+            WebhookEvent.STRATEGY_STOPPED,
+            WebhookEvent.STRATEGY_ERROR,
+            WebhookEvent.BACKTEST_COMPLETED,
+            WebhookEvent.BACKTEST_FAILED,
+        ]
+        for event in events:
+            assert "." not in event, f"WebhookEvent {event} uses dot.notation instead of SCREAMING_SNAKE_CASE"
+            assert event == event.upper(), f"WebhookEvent {event} is not SCREAMING_SNAKE_CASE"
+
+    def test_ai_query_body_uses_query_field(self):
+        """ai_query() must send { query } not { question } (#89)."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.ai_query)
+        assert '"query"' in source or "'query'" in source
+        assert '"question"' not in source and "'question'" not in source
+
+    def test_create_strategy_from_description_body_uses_description_field(self):
+        """create_strategy_from_description() must send { description } not { query } (#90)."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.create_strategy_from_description)
+        assert '"description"' in source or "'description'" in source
+
+    def test_start_strategy_sends_lowercase_mode(self):
+        """start_strategy() must not call .upper() on mode (#92)."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.start_strategy)
+        assert ".upper()" not in source, "start_strategy() must not uppercase the mode value"


### PR DESCRIPTION
## Problem

Four breaking compat regressions from previous fixes caused every call to `ai_query()`, `create_strategy_from_description()`, `create_webhook()`, and `start_strategy()` to return HTTP 400.

## What changed

| Method | Before (broken) | After (correct) | Issue |
|--------|-----------------|------------------|-------|
| `ai_query()` | `{ "question": ... }` | `{ "query": ... }` | closes #89 |
| `create_strategy_from_description()` | `{ "query": ... }` | `{ "description": ... }` | closes #90 |
| `WebhookEvent` values | `order.filled` (dot.notation) | `ORDER_FILLED` (SCREAMING_SNAKE) | closes #91 |
| `start_strategy()` mode | `.upper()` applied | lowercase passthrough | closes #92 |

Fixed in both sync (`PolyforgeClient`) and async (`AsyncPolyforgeClient`) clients.

## Tests added

4 new regression tests:
- `test_webhook_event_values_are_screaming_snake_case`
- `test_ai_query_body_uses_query_field`
- `test_create_strategy_from_description_body_uses_description_field`
- `test_start_strategy_sends_lowercase_mode`

All 49 tests pass.

closes #89, closes #90, closes #91, closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)