### PR TITLE
fix(security): add client-side validation for financial order parameters (closes #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.9] — 2026-04-13
+
+### Security
+- **Financial parameter validation**: add `_validate_financial_param()` helper that rejects NaN, Infinity, negative, and zero values — applied to `place_order`, `place_smart_order`, `provide_liquidity`, and `split_position` in both sync and async clients; prevents malformed orders from reaching the API (closes #88)
+
 ## [1.6.8] — 2026-04-13
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ipaddress
 import json as _json
 import logging as _log
+import math
 import re
 import socket
 from dataclasses import fields
@@ -162,6 +163,23 @@ def _strip_none(params: dict[str, Any]) -> dict[str, Any]:
 def _encode_path(segment: str) -> str:
     """URL-encode a path parameter to prevent path traversal attacks (CWE-22)."""
     return quote(str(segment), safe="")
+
+
+def _validate_financial_param(name: str, value: float) -> None:
+    """Reject NaN, Infinity, negative, and zero values for financial parameters.
+
+    Raises:
+        TypeError: if *value* is not a real number (int or float).
+        ValueError: if *value* is NaN, infinite, zero, or negative.
+    """
+    if not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a number, got {type(value).__name__}")
+    if math.isnan(value):
+        raise ValueError(f"{name} must not be NaN")
+    if math.isinf(value):
+        raise ValueError(f"{name} must not be Infinity")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
 
 
 _BLOCKED_HOSTNAMES: set[str] = {
@@ -509,6 +527,8 @@ class PolyforgeClient:
         order_type: str = "GTC",
     ) -> PlaceOrderResponse:
         """Place a direct buy or sell order on a prediction market."""
+        _validate_financial_param("size", size)
+        _validate_financial_param("price", price)
         data = self._post("/api/v1/orders/place", json={
             "tokenId": token_id,
             "side": side,
@@ -545,6 +565,8 @@ class PolyforgeClient:
 
     def split_position(self, token_id: str, size: float, price: float) -> PlaceOrderResponse:
         """Split a position into smaller positions."""
+        _validate_financial_param("size", size)
+        _validate_financial_param("price", price)
         data = self._post("/api/v1/orders/split", json={"tokenId": token_id, "size": size, "price": price})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
 
@@ -597,6 +619,19 @@ class PolyforgeClient:
         price_b: float | None = None,
     ) -> PlaceSmartOrderResponse:
         """Place an advanced smart order (TWAP, DCA, BRACKET, or OCO)."""
+        _validate_financial_param("total_size", total_size)
+        if limit_price is not None:
+            _validate_financial_param("limit_price", limit_price)
+        if entry_price is not None:
+            _validate_financial_param("entry_price", entry_price)
+        if take_profit_price is not None:
+            _validate_financial_param("take_profit_price", take_profit_price)
+        if stop_loss_price is not None:
+            _validate_financial_param("stop_loss_price", stop_loss_price)
+        if price_a is not None:
+            _validate_financial_param("price_a", price_a)
+        if price_b is not None:
+            _validate_financial_param("price_b", price_b)
         body: dict[str, Any] = {
             "type": type,
             "tokenId": token_id,
@@ -795,6 +830,8 @@ class PolyforgeClient:
         )
 
     def provide_liquidity(self, token_id: str, spread: float, size: float) -> LpPosition:
+        _validate_financial_param("spread", spread)
+        _validate_financial_param("size", size)
         data = self._post("/api/v1/lp/provide", json={"tokenId": token_id, "spread": spread, "size": size})
         return LpPosition(
             buy_order_id=data.get("buyOrderId", ""),
@@ -1060,6 +1097,8 @@ class AsyncPolyforgeClient:
         order_type: str = "GTC",
     ) -> PlaceOrderResponse:
         """Place a direct buy or sell order on a prediction market."""
+        _validate_financial_param("size", size)
+        _validate_financial_param("price", price)
         data = await self._post("/api/v1/orders/place", json={
             "tokenId": token_id,
             "side": side,
@@ -1096,6 +1135,8 @@ class AsyncPolyforgeClient:
 
     async def split_position(self, token_id: str, size: float, price: float) -> PlaceOrderResponse:
         """Split a position into smaller positions."""
+        _validate_financial_param("size", size)
+        _validate_financial_param("price", price)
         data = await self._post("/api/v1/orders/split", json={"tokenId": token_id, "size": size, "price": price})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
 
@@ -1144,6 +1185,19 @@ class AsyncPolyforgeClient:
         price_b: float | None = None,
     ) -> PlaceSmartOrderResponse:
         """Place an advanced smart order (TWAP, DCA, BRACKET, or OCO)."""
+        _validate_financial_param("total_size", total_size)
+        if limit_price is not None:
+            _validate_financial_param("limit_price", limit_price)
+        if entry_price is not None:
+            _validate_financial_param("entry_price", entry_price)
+        if take_profit_price is not None:
+            _validate_financial_param("take_profit_price", take_profit_price)
+        if stop_loss_price is not None:
+            _validate_financial_param("stop_loss_price", stop_loss_price)
+        if price_a is not None:
+            _validate_financial_param("price_a", price_a)
+        if price_b is not None:
+            _validate_financial_param("price_b", price_b)
         body: dict[str, Any] = {
             "type": type,
             "tokenId": token_id,
@@ -1339,6 +1393,8 @@ class AsyncPolyforgeClient:
         )
 
     async def provide_liquidity(self, token_id: str, spread: float, size: float) -> LpPosition:
+        _validate_financial_param("spread", spread)
+        _validate_financial_param("size", size)
         data = await self._post("/api/v1/lp/provide", json={"tokenId": token_id, "spread": spread, "size": size})
         return LpPosition(
             buy_order_id=data.get("buyOrderId", ""),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 from polyforge.client import (
     PolyforgeClient,
     AsyncPolyforgeClient,
+    _validate_financial_param,
     _validate_webhook_url,
     _is_ip_blocked,
     _resolve_and_validate_ips,
@@ -438,3 +439,124 @@ class TestPlatformContractCompliance:
 
         source = inspect.getsource(PolyforgeClient.start_strategy)
         assert ".upper()" not in source, "start_strategy() must not uppercase the mode value"
+
+
+class TestFinancialParamValidation:
+    """Test _validate_financial_param rejects dangerous values (#88)."""
+
+    def test_rejects_nan(self):
+        with pytest.raises(ValueError, match="must not be NaN"):
+            _validate_financial_param("size", float("nan"))
+
+    def test_rejects_positive_infinity(self):
+        with pytest.raises(ValueError, match="must not be Infinity"):
+            _validate_financial_param("price", float("inf"))
+
+    def test_rejects_negative_infinity(self):
+        with pytest.raises(ValueError, match="must not be Infinity"):
+            _validate_financial_param("price", float("-inf"))
+
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            _validate_financial_param("size", 0)
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            _validate_financial_param("size", -1.0)
+
+    def test_rejects_non_number(self):
+        with pytest.raises(TypeError, match="must be a number"):
+            _validate_financial_param("size", "10")  # type: ignore[arg-type]
+
+    def test_accepts_positive_float(self):
+        _validate_financial_param("size", 1.5)  # should not raise
+
+    def test_accepts_positive_int(self):
+        _validate_financial_param("size", 10)  # should not raise
+
+
+class TestPlaceOrderValidation:
+    """Ensure place_order rejects invalid financial params before HTTP call (#88)."""
+
+    def test_place_order_rejects_nan_size(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must not be NaN"):
+            client.place_order("tok", "BUY", "YES", float("nan"), 0.5)
+        client.close()
+
+    def test_place_order_rejects_negative_price(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be positive"):
+            client.place_order("tok", "BUY", "YES", 10.0, -0.5)
+        client.close()
+
+    def test_split_position_rejects_zero_size(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be positive"):
+            client.split_position("tok", 0, 0.5)
+        client.close()
+
+    def test_place_smart_order_rejects_inf_total_size(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must not be Infinity"):
+            client.place_smart_order(
+                type="TWAP", token_id="tok", side="BUY",
+                outcome="YES", total_size=float("inf"),
+            )
+        client.close()
+
+    def test_place_smart_order_rejects_nan_limit_price(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must not be NaN"):
+            client.place_smart_order(
+                type="TWAP", token_id="tok", side="BUY",
+                outcome="YES", total_size=10.0, limit_price=float("nan"),
+            )
+        client.close()
+
+    def test_provide_liquidity_rejects_negative_spread(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be positive"):
+            client.provide_liquidity("tok", -0.01, 100.0)
+        client.close()
+
+    def test_provide_liquidity_rejects_zero_size(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be positive"):
+            client.provide_liquidity("tok", 0.05, 0)
+        client.close()
+
+
+class TestAsyncPlaceOrderValidation:
+    """Ensure async client also validates financial params (#88).
+
+    The validation helper is a plain function called before any await,
+    so we use inspect.getsource to verify calls are present in each method.
+    """
+
+    def test_async_place_order_calls_validate(self):
+        """Async place_order must call _validate_financial_param for size and price."""
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.place_order)
+        assert '_validate_financial_param("size"' in source
+        assert '_validate_financial_param("price"' in source
+
+    def test_async_split_position_calls_validate(self):
+        """Async split_position must call _validate_financial_param for size and price."""
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.split_position)
+        assert '_validate_financial_param("size"' in source
+        assert '_validate_financial_param("price"' in source
+
+    def test_async_place_smart_order_calls_validate(self):
+        """Async place_smart_order must call _validate_financial_param for total_size."""
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.place_smart_order)
+        assert '_validate_financial_param("total_size"' in source
+
+    def test_async_provide_liquidity_calls_validate(self):
+        """Async provide_liquidity must call _validate_financial_param for spread and size."""
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.provide_liquidity)
+        assert '_validate_financial_param("spread"' in source
+        assert '_validate_financial_param("size"' in source


### PR DESCRIPTION
## Summary
- Add `_validate_financial_param()` helper that rejects NaN, Infinity, negative, and zero values with clear error messages (TypeError for non-numbers, ValueError for invalid values)
- Apply validation to all financial parameters in `place_order` (size, price), `place_smart_order` (total_size + all optional price params), `provide_liquidity` (spread, size), and `split_position` (size, price)
- Both `PolyforgeClient` (sync) and `AsyncPolyforgeClient` (async) are covered

## Test plan
- [x] 8 unit tests for `_validate_financial_param` helper (NaN, +Inf, -Inf, zero, negative, non-number, valid float, valid int)
- [x] 7 integration tests on sync client methods (place_order, split_position, place_smart_order, provide_liquidity)
- [x] 4 source-inspection tests verifying async client methods call the validator
- [x] All 68 tests pass (`python3 -m pytest tests/ -v`)

Closes #88