### PR TITLE
fix(compat): rename Market.name to Market.title (closes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.10] — 2026-04-13
+
+### Fixed
+- **BREAKING** `Market` model: rename `name` field to `title` to match platform response — `list_markets()` and `get_market()` were returning empty titles because the platform sends `title`, not `name` (closes #43)
+
 ## [1.6.9] — 2026-04-13
 
 ### Security

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -306,7 +306,7 @@ class PolyforgeClient:
         with PolyforgeClient(api_key="pk_...") as client:
             markets = client.list_markets(limit=5)
             for m in markets.items:
-                print(m.name, m.price)
+                print(m.title, m.price)
     """
 
     def __init__(
@@ -876,7 +876,7 @@ class AsyncPolyforgeClient:
         async with AsyncPolyforgeClient(api_key="pk_...") as client:
             markets = await client.list_markets(limit=5)
             for m in markets.items:
-                print(m.name, m.price)
+                print(m.title, m.price)
     """
 
     def __init__(

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -47,7 +47,7 @@ class Market:
     """A trading market / pair."""
 
     id: str = ""
-    name: str = ""
+    title: str = ""
     symbol: str = ""
     category: str = ""
     base_token: Token | None = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 from polyforge.client import (
     PolyforgeClient,
     AsyncPolyforgeClient,
+    _parse,
     _validate_financial_param,
     _validate_webhook_url,
     _is_ip_blocked,
@@ -201,14 +202,27 @@ class TestModelParsing:
         """Should instantiate Market model."""
         market = Market(
             id="btc-usd",
-            name="Bitcoin / US Dollar",
+            title="Bitcoin / US Dollar",
             symbol="BTC/USD",
             category="crypto",
             price=45000.0,
         )
         assert market.id == "btc-usd"
-        assert market.name == "Bitcoin / US Dollar"
+        assert market.title == "Bitcoin / US Dollar"
         assert market.price == 45000.0
+
+    def test_market_parses_title_from_api_response(self):
+        """Platform returns 'title' not 'name' — _parse must map it correctly (#43)."""
+        api_response = {
+            "id": "0xabc",
+            "title": "Will BTC reach $100K by June?",
+            "symbol": "BTC-100K",
+            "category": "Crypto",
+            "price": 0.65,
+        }
+        market = _parse(Market, api_response)
+        assert market.title == "Will BTC reach $100K by June?"
+        assert market.id == "0xabc"
 
     def test_strategy_model_instantiation(self):
         """Should instantiate Strategy model."""


### PR DESCRIPTION
## Summary
- Renamed `name` field to `title` in `Market` dataclass to match platform API response
- Platform sends `title`, not `name` — every `list_markets()` and `get_market()` call returned empty market titles
- Updated docstrings in both sync and async clients

## What changed
- `src/polyforge/models.py`: `Market.name` → `Market.title`
- `src/polyforge/client.py`: Updated docstring examples (`m.name` → `m.title`)
- `tests/test_client.py`: Updated existing market test + added `_parse` integration test verifying `title` field mapping

## Test plan
- [x] New test: `test_market_parses_title_from_api_response` (verifies `_parse` maps `title` correctly)
- [x] Existing test updated: `test_market_model_instantiation`
- [x] All 69 tests pass

closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)