### PR TITLE
fix(compat): fix WebhookEvent — remove phantom events, add missing, fix name (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.11] — 2026-04-13
+
+### Fixed
+- **BREAKING** `WebhookEvent`: replace 5 phantom events (`ORDER_PLACED`, `ORDER_CANCELLED`, `STRATEGY_STARTED`, `STRATEGY_STOPPED`, `BACKTEST_FAILED`) with the correct platform events (`WHALE_TRADE`, `NEWS_SIGNAL`, `DAILY_LOSS_LIMIT`, `MARKET_RESOLVED`, `PRICE_ALERT`); fix `BACKTEST_COMPLETED` → `BACKTEST_COMPLETE` — webhook creation was returning HTTP 400 for non-existent event names (closes #80)
+
 ## [1.6.10] — 2026-04-13
 
 ### Fixed

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -249,19 +249,24 @@ class CopyConfig:
 class WebhookEvent:
     """Constants for webhook event names (SCREAMING_SNAKE_CASE as expected by the platform).
 
+    These match the platform's ``CreateWebhookDto`` validation exactly::
+
+        @IsIn(['ORDER_FILLED','STRATEGY_ERROR','WHALE_TRADE','NEWS_SIGNAL',
+               'BACKTEST_COMPLETE','DAILY_LOSS_LIMIT','MARKET_RESOLVED','PRICE_ALERT'])
+
     Usage::
 
         client.create_webhook(url="https://...", events=[WebhookEvent.ORDER_FILLED])
     """
 
     ORDER_FILLED = "ORDER_FILLED"
-    ORDER_PLACED = "ORDER_PLACED"
-    ORDER_CANCELLED = "ORDER_CANCELLED"
-    STRATEGY_STARTED = "STRATEGY_STARTED"
-    STRATEGY_STOPPED = "STRATEGY_STOPPED"
     STRATEGY_ERROR = "STRATEGY_ERROR"
-    BACKTEST_COMPLETED = "BACKTEST_COMPLETED"
-    BACKTEST_FAILED = "BACKTEST_FAILED"
+    WHALE_TRADE = "WHALE_TRADE"
+    NEWS_SIGNAL = "NEWS_SIGNAL"
+    BACKTEST_COMPLETE = "BACKTEST_COMPLETE"
+    DAILY_LOSS_LIMIT = "DAILY_LOSS_LIMIT"
+    MARKET_RESOLVED = "MARKET_RESOLVED"
+    PRICE_ALERT = "PRICE_ALERT"
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -416,21 +416,39 @@ class TestContextManagers:
 class TestPlatformContractCompliance:
     """Regression tests for platform DTO field name compliance (#89-#92)."""
 
-    def test_webhook_event_values_are_screaming_snake_case(self):
-        """WebhookEvent values must use SCREAMING_SNAKE_CASE, not dot.notation (#91)."""
-        events = [
+    def test_webhook_event_values_match_platform_dto(self):
+        """WebhookEvent values must match platform CreateWebhookDto validation exactly (#80, #91)."""
+        # These are the exact 8 events accepted by the platform's @IsIn() validator
+        platform_events = {
+            "ORDER_FILLED", "STRATEGY_ERROR", "WHALE_TRADE", "NEWS_SIGNAL",
+            "BACKTEST_COMPLETE", "DAILY_LOSS_LIMIT", "MARKET_RESOLVED", "PRICE_ALERT",
+        }
+        sdk_events = {
             WebhookEvent.ORDER_FILLED,
-            WebhookEvent.ORDER_PLACED,
-            WebhookEvent.ORDER_CANCELLED,
-            WebhookEvent.STRATEGY_STARTED,
-            WebhookEvent.STRATEGY_STOPPED,
             WebhookEvent.STRATEGY_ERROR,
-            WebhookEvent.BACKTEST_COMPLETED,
-            WebhookEvent.BACKTEST_FAILED,
-        ]
-        for event in events:
-            assert "." not in event, f"WebhookEvent {event} uses dot.notation instead of SCREAMING_SNAKE_CASE"
+            WebhookEvent.WHALE_TRADE,
+            WebhookEvent.NEWS_SIGNAL,
+            WebhookEvent.BACKTEST_COMPLETE,
+            WebhookEvent.DAILY_LOSS_LIMIT,
+            WebhookEvent.MARKET_RESOLVED,
+            WebhookEvent.PRICE_ALERT,
+        }
+        assert sdk_events == platform_events, (
+            f"SDK events {sdk_events} don't match platform events {platform_events}"
+        )
+        for event in sdk_events:
+            assert "." not in event, f"WebhookEvent {event} uses dot.notation"
             assert event == event.upper(), f"WebhookEvent {event} is not SCREAMING_SNAKE_CASE"
+
+    def test_webhook_event_no_phantom_events(self):
+        """WebhookEvent must not define events that don't exist in the platform (#80)."""
+        # These were previously defined but don't exist in the platform's validation
+        assert not hasattr(WebhookEvent, "ORDER_PLACED"), "ORDER_PLACED is a phantom event"
+        assert not hasattr(WebhookEvent, "ORDER_CANCELLED"), "ORDER_CANCELLED is a phantom event"
+        assert not hasattr(WebhookEvent, "STRATEGY_STARTED"), "STRATEGY_STARTED is a phantom event"
+        assert not hasattr(WebhookEvent, "STRATEGY_STOPPED"), "STRATEGY_STOPPED is a phantom event"
+        assert not hasattr(WebhookEvent, "BACKTEST_FAILED"), "BACKTEST_FAILED is a phantom event"
+        assert not hasattr(WebhookEvent, "BACKTEST_COMPLETED"), "BACKTEST_COMPLETED is phantom (correct name is BACKTEST_COMPLETE)"
 
     def test_ai_query_body_uses_query_field(self):
         """ai_query() must send { query } not { question } (#89)."""


### PR DESCRIPTION
## Summary

- **Removed 5 phantom events** that don't exist in the platform's `CreateWebhookDto` validation: `ORDER_PLACED`, `ORDER_CANCELLED`, `STRATEGY_STARTED`, `STRATEGY_STOPPED`, `BACKTEST_FAILED`
- **Added 5 missing events**: `WHALE_TRADE`, `NEWS_SIGNAL`, `DAILY_LOSS_LIMIT`, `MARKET_RESOLVED`, `PRICE_ALERT`
- **Fixed name mismatch**: `BACKTEST_COMPLETED` → `BACKTEST_COMPLETE`

The platform's `@IsIn()` validator accepts exactly 8 events — the SDK now matches all 8.

## Test plan

- [x] 2 new regression tests: event set matches platform + phantom events removed
- [x] All 70 tests pass
- [x] Verified against platform source: `services/api-service/src/webhooks/dto/create-webhook.dto.ts`

closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)