### PR TITLE
fix(errors): add suggestion field and fix requestId source (closes #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.12] — 2026-04-13
+
+### Fixed
+- **`PolyforgeError.suggestion`**: add optional `suggestion` field to `PolyforgeError` — platform error responses include a `suggestion` string but it was silently dropped (closes #93)
+- **`PolyforgeError.request_id`**: read `requestId` from the JSON body instead of the `x-request-id` HTTP header — the platform sends the request ID in the response body, so `request_id` was always empty (closes #93)
+
 ## [1.6.11] — 2026-04-13
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -136,9 +136,10 @@ def _raise_for_status(response: httpx.Response) -> None:
 
     message = body.get("message") or body.get("error") or response.reason_phrase or "Unknown error"
     code = body.get("code", "")
-    request_id = response.headers.get("x-request-id", "")
+    request_id = body.get("requestId", "")
+    suggestion = body.get("suggestion") or None
 
-    kwargs = dict(status_code=response.status_code, code=code, request_id=request_id)
+    kwargs = dict(status_code=response.status_code, code=code, request_id=request_id, suggestion=suggestion)
 
     match response.status_code:
         case 401:

--- a/src/polyforge/errors.py
+++ b/src/polyforge/errors.py
@@ -20,18 +20,21 @@ class PolyforgeError(Exception):
         status_code: int = 0,
         code: str = "",
         request_id: str = "",
+        suggestion: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.code = code
         self.message = message
         self.request_id = request_id
+        self.suggestion = suggestion
 
     def __repr__(self) -> str:
         return (
             f"PolyforgeError(status_code={self.status_code!r}, "
             f"code={self.code!r}, message={self.message!r}, "
-            f"request_id={self.request_id!r})"
+            f"request_id={self.request_id!r}, "
+            f"suggestion={self.suggestion!r})"
         )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,14 @@
 """Basic smoke tests for PolyforgeClient."""
 
+import json
+
+import httpx
 import pytest
 from polyforge.client import (
     PolyforgeClient,
     AsyncPolyforgeClient,
     _parse,
+    _raise_for_status,
     _validate_financial_param,
     _validate_webhook_url,
     _is_ip_blocked,
@@ -193,6 +197,109 @@ class TestErrorClasses:
         assert "PolyforgeError" in repr_str
         assert "400" in repr_str
         assert "BAD_REQUEST" in repr_str
+
+    def test_error_suggestion_field(self):
+        """Should accept and store optional suggestion field."""
+        error = PolyforgeError(
+            "Bad request",
+            status_code=400,
+            code="INVALID_PARAM",
+            suggestion="Use a valid market ID instead.",
+        )
+        assert error.suggestion == "Use a valid market ID instead."
+
+    def test_error_suggestion_defaults_to_none(self):
+        """Suggestion should default to None when not provided."""
+        error = PolyforgeError("Oops", status_code=500)
+        assert error.suggestion is None
+
+    def test_error_repr_includes_suggestion(self):
+        """Repr should include the suggestion field."""
+        error = PolyforgeError(
+            "Bad request",
+            status_code=400,
+            code="BAD",
+            suggestion="Try again",
+        )
+        assert "suggestion='Try again'" in repr(error)
+
+
+def _make_error_response(
+    status_code: int,
+    body: dict,
+    headers: dict | None = None,
+) -> httpx.Response:
+    """Build a fake httpx.Response for _raise_for_status tests."""
+    resp = httpx.Response(
+        status_code=status_code,
+        content=json.dumps(body).encode(),
+        headers={"content-type": "application/json", **(headers or {})},
+        request=httpx.Request("GET", "https://api.polyforge.io/test"),
+    )
+    return resp
+
+
+class TestRaiseForStatus:
+    """Test _raise_for_status reads fields from the JSON body correctly."""
+
+    def test_reads_request_id_from_body(self):
+        """requestId should come from JSON body, not HTTP headers (#93)."""
+        resp = _make_error_response(
+            400,
+            {"message": "Invalid", "code": "BAD", "requestId": "req-abc-123"},
+            headers={"x-request-id": "wrong-header-value"},
+        )
+        with pytest.raises(PolyforgeError) as exc_info:
+            _raise_for_status(resp)
+        assert exc_info.value.request_id == "req-abc-123"
+
+    def test_reads_suggestion_from_body(self):
+        """suggestion should be extracted from the JSON body (#93)."""
+        resp = _make_error_response(
+            422,
+            {
+                "message": "Invalid parameter",
+                "code": "VALIDATION_ERROR",
+                "requestId": "req-1",
+                "suggestion": "Use ISO-8601 date format.",
+            },
+        )
+        with pytest.raises(PolyforgeError) as exc_info:
+            _raise_for_status(resp)
+        assert exc_info.value.suggestion == "Use ISO-8601 date format."
+
+    def test_suggestion_is_none_when_absent(self):
+        """suggestion should be None when the body does not include it."""
+        resp = _make_error_response(
+            400,
+            {"message": "Nope", "code": "BAD"},
+        )
+        with pytest.raises(PolyforgeError) as exc_info:
+            _raise_for_status(resp)
+        assert exc_info.value.suggestion is None
+
+    def test_request_id_empty_when_absent_from_body(self):
+        """request_id should be empty string when not in JSON body."""
+        resp = _make_error_response(
+            400,
+            {"message": "Nope"},
+            headers={"x-request-id": "header-only"},
+        )
+        with pytest.raises(PolyforgeError) as exc_info:
+            _raise_for_status(resp)
+        # Must NOT fall back to the header value
+        assert exc_info.value.request_id == ""
+
+    def test_correct_subclass_raised(self):
+        """Should still raise the right subclass per status code."""
+        resp = _make_error_response(
+            429,
+            {"message": "Slow down", "code": "RATE_LIMITED", "requestId": "r1", "suggestion": "Wait 60s."},
+        )
+        with pytest.raises(RateLimitError) as exc_info:
+            _raise_for_status(resp)
+        assert exc_info.value.request_id == "r1"
+        assert exc_info.value.suggestion == "Wait 60s."
 
 
 class TestModelParsing:


### PR DESCRIPTION
## Summary
- Add optional `suggestion` field to `PolyforgeError` — platform error responses include a `suggestion` string but it was silently dropped
- Fix `requestId`: read from JSON body instead of `x-request-id` HTTP header — the platform sends request ID in the response body, so `request_id` was always `None`/empty
- Add 5 new tests covering both fixes via `_raise_for_status` unit tests

## Test plan
- [x] `python3 -m pytest` — 78 tests pass
- [x] `ruff check` — clean on changed files

closes #93