### PR TITLE
fix(compat): add missing query params to list_markets and list_strategies (closes #74, #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.15] — 2026-04-13
+
+### Fixed
+- `list_markets()`: add `sort` and `closed` optional parameters to both sync and async clients — platform supports filtering by sort order and closed status but SDK did not expose them (closes #74)
+- `list_strategies()`: add `sort`, `page`, and `limit` optional parameters to both sync and async clients — platform supports pagination and sorting but SDK only exposed `status` filter (closes #77)
+
 ## [1.6.14] — 2026-04-13
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -391,12 +391,21 @@ class PolyforgeClient:
         *,
         search: str | None = None,
         category: str | None = None,
+        sort: str | None = None,
+        closed: bool | None = None,
         limit: int = 10,
         page: int = 1,
     ) -> PaginatedResponse[Market]:
         raw = self._get(
             "/api/v1/markets",
-            params={"search": search, "category": category, "limit": limit, "page": page},
+            params={
+                "search": search,
+                "category": category,
+                "sort": sort,
+                "closed": closed,
+                "limit": limit,
+                "page": page,
+            },
         )
         parsed = [_parse(Market, m) for m in raw["data"]]
         return PaginatedResponse(
@@ -413,8 +422,18 @@ class PolyforgeClient:
 
     # -- Strategies --
 
-    def list_strategies(self, *, status: str | None = None) -> list[Strategy]:
-        data = self._get("/api/v1/strategies", params={"status": status})
+    def list_strategies(
+        self,
+        *,
+        status: str | None = None,
+        sort: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> list[Strategy]:
+        data = self._get(
+            "/api/v1/strategies",
+            params={"status": status, "sort": sort, "page": page, "limit": limit},
+        )
         # Backend returns PaginatedResponse<Strategy> with 'data' field
         items = data["data"]
         return [_parse(Strategy, s) for s in items]
@@ -1075,12 +1094,21 @@ class AsyncPolyforgeClient:
         *,
         search: str | None = None,
         category: str | None = None,
+        sort: str | None = None,
+        closed: bool | None = None,
         limit: int = 10,
         page: int = 1,
     ) -> PaginatedResponse[Market]:
         raw = await self._get(
             "/api/v1/markets",
-            params={"search": search, "category": category, "limit": limit, "page": page},
+            params={
+                "search": search,
+                "category": category,
+                "sort": sort,
+                "closed": closed,
+                "limit": limit,
+                "page": page,
+            },
         )
         parsed = [_parse(Market, m) for m in raw["data"]]
         return PaginatedResponse(
@@ -1097,8 +1125,18 @@ class AsyncPolyforgeClient:
 
     # -- Strategies --
 
-    async def list_strategies(self, *, status: str | None = None) -> list[Strategy]:
-        data = await self._get("/api/v1/strategies", params={"status": status})
+    async def list_strategies(
+        self,
+        *,
+        status: str | None = None,
+        sort: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> list[Strategy]:
+        data = await self._get(
+            "/api/v1/strategies",
+            params={"status": status, "sort": sort, "page": page, "limit": limit},
+        )
         # Backend returns PaginatedResponse<Strategy> with 'data' field
         items = data["data"]
         return [_parse(Strategy, s) for s in items]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1102,3 +1102,66 @@ class TestStrategyEnums:
 
     def test_strategy_exec_mode_values(self):
         assert set(v.value for v in StrategyExecMode) == {"TICK", "EVENT", "HYBRID"}
+
+
+class TestListMarketsSortClosedParams:
+    """Tests for sort and closed params on list_markets (#74)."""
+
+    def test_list_markets_accepts_sort_and_closed_params(self):
+        """list_markets() signature must accept sort and closed keyword args."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_markets)
+        param_names = set(sig.parameters.keys())
+        assert "sort" in param_names, "list_markets() missing 'sort' parameter"
+        assert "closed" in param_names, "list_markets() missing 'closed' parameter"
+
+    def test_async_list_markets_accepts_sort_and_closed_params(self):
+        """AsyncPolyforgeClient.list_markets() must also accept sort and closed."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.list_markets)
+        param_names = set(sig.parameters.keys())
+        assert "sort" in param_names, "async list_markets() missing 'sort' parameter"
+        assert "closed" in param_names, "async list_markets() missing 'closed' parameter"
+
+    def test_list_markets_sort_and_closed_passed_in_params(self):
+        """list_markets() must pass sort and closed to the HTTP params dict."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.list_markets)
+        assert '"sort"' in source or "'sort'" in source
+        assert '"closed"' in source or "'closed'" in source
+
+
+class TestListStrategiesSortPageLimitParams:
+    """Tests for sort, page, limit params on list_strategies (#77)."""
+
+    def test_list_strategies_accepts_sort_page_limit(self):
+        """list_strategies() signature must accept sort, page, limit keyword args."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_strategies)
+        param_names = set(sig.parameters.keys())
+        assert "sort" in param_names, "list_strategies() missing 'sort' parameter"
+        assert "page" in param_names, "list_strategies() missing 'page' parameter"
+        assert "limit" in param_names, "list_strategies() missing 'limit' parameter"
+
+    def test_async_list_strategies_accepts_sort_page_limit(self):
+        """AsyncPolyforgeClient.list_strategies() must also accept sort, page, limit."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.list_strategies)
+        param_names = set(sig.parameters.keys())
+        assert "sort" in param_names, "async list_strategies() missing 'sort' parameter"
+        assert "page" in param_names, "async list_strategies() missing 'page' parameter"
+        assert "limit" in param_names, "async list_strategies() missing 'limit' parameter"
+
+    def test_list_strategies_params_passed_to_request(self):
+        """list_strategies() must pass sort, page, limit to the HTTP params dict."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.list_strategies)
+        assert '"sort"' in source or "'sort'" in source
+        assert '"page"' in source or "'page'" in source
+        assert '"limit"' in source or "'limit'" in source


### PR DESCRIPTION
## Summary
- **#74**: Add `sort` (str|None) and `closed` (bool|None) params to `list_markets()` in both sync and async clients
- **#77**: Add `sort` (str|None), `page` (int=1), `limit` (int=20) params to `list_strategies()` in both sync and async clients
- **#54, #58, #59, #60**: Already fixed in v1.6.14 — verified during this pass

## Test plan
- [x] All 116 existing tests pass
- [x] 6 new tests cover changed method signatures (sync + async) and param forwarding
- [x] ruff check shows no new lint errors (pre-existing E701s only)

closes #74, closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)