### PR TITLE
fix(models): align Alert + CopyConfig with platform Prisma schema (closes #107, closes #108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.6.19] — 2026-04-14
+
+### Fixed
+- **BREAKING:** `Alert` model: replaced phantom fields (`name`, `condition`, `market_id`, `threshold`, `enabled`) with correct platform fields (`token_id`, `direction`, `price`, `persistent`, `triggered`, `triggered_at`) to match `PriceAlert` Prisma model (closes #107)
+- **BREAKING:** `CopyConfig` model: replaced phantom fields (`source_wallet`, `label`, `max_position_size`, `enabled`, `total_copied_trades`) with correct platform fields (`target_wallet`, `mode`, `size_value`, `max_exposure`, `max_daily_loss`, `price_offset`, `status`, `total_pnl`, `total_copied`, `updated_at`, `stopped_at`) to match `CopyConfig` Prisma model (closes #108)
+- `list_alerts()`, `list_copy_configs()`, `list_webhooks()`: fixed response parsing for endpoints that return raw arrays instead of `PaginatedResponse` — previously would crash with `TypeError` when platform returns `[...]` instead of `{data: [...]}`
+
 ## [1.6.18] — 2026-04-13
 
 ### Added

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -952,7 +952,7 @@ class PolyforgeClient:
 
     def list_alerts(self) -> list[Alert]:
         data = self._get("/api/v1/alerts")
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(Alert, a) for a in items]
 
     def create_alert(
@@ -1096,13 +1096,12 @@ class PolyforgeClient:
 
     def list_copy_configs(self) -> list[CopyConfig]:
         data = self._get("/api/v1/copy")
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(CopyConfig, c) for c in items]
 
     def list_webhooks(self) -> list[Webhook]:
         data = self._get("/api/v1/webhooks")
-        # Backend returns PaginatedResponse<Webhook> with 'data' field
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(Webhook, w) for w in items]
 
     def create_webhook(self, url: str, events: list[str]) -> Webhook:
@@ -1864,7 +1863,7 @@ class AsyncPolyforgeClient:
 
     async def list_alerts(self) -> list[Alert]:
         data = await self._get("/api/v1/alerts")
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(Alert, a) for a in items]
 
     async def create_alert(
@@ -2008,13 +2007,12 @@ class AsyncPolyforgeClient:
 
     async def list_copy_configs(self) -> list[CopyConfig]:
         data = await self._get("/api/v1/copy")
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(CopyConfig, c) for c in items]
 
     async def list_webhooks(self) -> list[Webhook]:
         data = await self._get("/api/v1/webhooks")
-        # Backend returns PaginatedResponse<Webhook> with 'data' field
-        items = data["data"]
+        items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(Webhook, w) for w in items]
 
     async def create_webhook(self, url: str, events: list[str]) -> Webhook:

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -295,15 +295,19 @@ class NewsSignal:
 
 @dataclass
 class Alert:
-    """A price or event alert."""
+    """A price alert on a specific token.
+
+    Field names match the platform ``PriceAlert`` Prisma model:
+    ``tokenId``, ``direction``, ``price``, ``persistent``.
+    """
 
     id: str = ""
-    name: str = ""
-    condition: str = ""
-    market_id: str = ""
-    threshold: float = 0.0
-    enabled: bool = True
-    last_triggered: str = ""
+    token_id: str = ""
+    direction: str = ""  # "above" | "below"
+    price: str = ""  # decimal string
+    persistent: bool = False
+    triggered: bool = False
+    triggered_at: str | None = None
     created_at: str = ""
 
 
@@ -311,17 +315,24 @@ class Alert:
 class CopyConfig:
     """A copy-trading configuration.
 
-    Field names match the platform contract (#45):
-    ``sourceWallet``, ``maxPositionSize``, ``label``, ``totalCopiedTrades``.
+    Field names match the platform ``CopyConfig`` Prisma model:
+    ``targetWallet``, ``mode``, ``sizeValue``, ``maxExposure``,
+    ``maxDailyLoss``, ``priceOffset``, ``status``.
     """
 
     id: str = ""
-    source_wallet: str = ""
-    label: str | None = None
-    max_position_size: float = 0.0
-    enabled: bool = True
-    total_copied_trades: int = 0
+    target_wallet: str = ""
+    mode: str = ""  # "PERCENTAGE" | "FIXED" | "MIRROR"
+    size_value: str = ""  # decimal string
+    max_exposure: str = ""  # decimal string
+    max_daily_loss: str = ""  # decimal string
+    price_offset: str = ""  # decimal string
+    status: str = ""  # "ACTIVE" | "PAUSED" | "STOPPED" | "ERROR"
+    total_pnl: str = ""  # decimal string
+    total_copied: int = 0
     created_at: str = ""
+    updated_at: str = ""
+    stopped_at: str | None = None
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,6 +24,7 @@ from polyforge.errors import (
 )
 from polyforge.models import (
     AiQueryResponse,
+    Alert,
     ConditionalOrder,
     CopyConfig,
     Market,
@@ -925,48 +926,113 @@ class TestOrderMonetaryFields:
         assert pos.unrealized_pnl == "10.00"
 
 
+class TestAlertFields:
+    """Tests for Alert field alignment with platform PriceAlert model (#107)."""
+
+    def test_alert_has_correct_fields(self):
+        """Alert must use platform PriceAlert field names."""
+        alert = Alert(
+            id="alert-1",
+            token_id="0xtoken",
+            direction="above",
+            price="0.65",
+            persistent=True,
+        )
+        assert alert.token_id == "0xtoken"
+        assert alert.direction == "above"
+        assert alert.price == "0.65"
+        assert alert.persistent is True
+
+    def test_alert_no_old_fields(self):
+        """Alert must not have legacy phantom field names."""
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(Alert)}
+        assert "name" not in field_names
+        assert "condition" not in field_names
+        assert "market_id" not in field_names
+        assert "threshold" not in field_names
+        assert "enabled" not in field_names
+        assert "last_triggered" not in field_names
+
+    def test_alert_parses_from_api(self):
+        """_parse must map camelCase platform fields to Alert."""
+        api_response = {
+            "id": "alert-1",
+            "tokenId": "0xtoken123",
+            "direction": "below",
+            "price": "0.42",
+            "persistent": False,
+            "triggered": False,
+            "triggeredAt": None,
+            "createdAt": "2026-04-01T00:00:00Z",
+        }
+        alert = _parse(Alert, api_response)
+        assert alert.token_id == "0xtoken123"
+        assert alert.direction == "below"
+        assert alert.price == "0.42"
+        assert alert.persistent is False
+        assert alert.created_at == "2026-04-01T00:00:00Z"
+
+
 class TestCopyConfigFields:
-    """Tests for CopyConfig field name alignment (#45)."""
+    """Tests for CopyConfig field alignment with platform Prisma model (#108)."""
 
     def test_copy_config_has_correct_fields(self):
         """CopyConfig must use platform field names."""
         cc = CopyConfig(
             id="cc-1",
-            source_wallet="0xabc",
-            label="My Copy",
-            max_position_size=500.0,
-            enabled=True,
-            total_copied_trades=42,
+            target_wallet="0xabc",
+            mode="PERCENTAGE",
+            size_value="10",
+            max_exposure="500",
+            max_daily_loss="100",
+            price_offset="0.01",
+            status="ACTIVE",
+            total_copied=42,
         )
-        assert cc.source_wallet == "0xabc"
-        assert cc.label == "My Copy"
-        assert cc.max_position_size == 500.0
-        assert cc.total_copied_trades == 42
+        assert cc.target_wallet == "0xabc"
+        assert cc.mode == "PERCENTAGE"
+        assert cc.size_value == "10"
+        assert cc.max_exposure == "500"
+        assert cc.max_daily_loss == "100"
+        assert cc.total_copied == 42
 
     def test_copy_config_no_old_fields(self):
         """CopyConfig must not have deprecated field names."""
         import dataclasses
         field_names = {f.name for f in dataclasses.fields(CopyConfig)}
+        assert "source_wallet" not in field_names
         assert "source_strategy_id" not in field_names
         assert "max_allocation" not in field_names
         assert "scale_factor" not in field_names
+        assert "label" not in field_names
+        assert "max_position_size" not in field_names
+        assert "total_copied_trades" not in field_names
+        assert "enabled" not in field_names
 
     def test_copy_config_parses_from_api(self):
         """_parse must map camelCase platform fields to CopyConfig."""
         api_response = {
             "id": "cc-1",
-            "sourceWallet": "0xdef",
-            "label": "Whale Copy",
-            "maxPositionSize": 1000.0,
-            "enabled": True,
-            "totalCopiedTrades": 15,
+            "targetWallet": "0xdef",
+            "mode": "FIXED",
+            "sizeValue": "250.50",
+            "maxExposure": "5000",
+            "maxDailyLoss": "200",
+            "priceOffset": "0.005",
+            "status": "ACTIVE",
+            "totalPnl": "125.00",
+            "totalCopied": 15,
             "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-04-01T00:00:00Z",
         }
         cc = _parse(CopyConfig, api_response)
-        assert cc.source_wallet == "0xdef"
-        assert cc.max_position_size == 1000.0
-        assert cc.total_copied_trades == 15
-        assert cc.label == "Whale Copy"
+        assert cc.target_wallet == "0xdef"
+        assert cc.mode == "FIXED"
+        assert cc.size_value == "250.50"
+        assert cc.max_exposure == "5000"
+        assert cc.total_copied == 15
+        assert cc.total_pnl == "125.00"
 
 
 class TestBacktestNoInitialBalance:


### PR DESCRIPTION
## Summary

- **Alert model**: Replaced phantom fields (`name`, `condition`, `market_id`, `threshold`, `enabled`) with correct platform fields (`token_id`, `direction`, `price`, `persistent`, `triggered`, `triggered_at`) — verified against `PriceAlert` Prisma model in PolyForge core
- **CopyConfig model**: Replaced phantom fields (`source_wallet`, `label`, `max_position_size`, `enabled`, `total_copied_trades`) with correct platform fields (`target_wallet`, `mode`, `size_value`, `max_exposure`, `max_daily_loss`, `price_offset`, `status`, `total_pnl`, `total_copied`, `updated_at`, `stopped_at`) — verified against `CopyConfig` Prisma model
- **list_alerts(), list_copy_configs(), list_webhooks()**: Fixed response parsing to handle raw array responses from endpoints that don't use `PaginatedResponse` wrapper (would previously crash with `TypeError`)
- Also closed #106 as false positive — `provide_liquidity()` fields match the platform DTO exactly

## Verification

All field names verified against PolyForge platform source:
- `prisma/schema.prisma` → `PriceAlert` model (line 758)
- `prisma/schema.prisma` → `CopyConfig` model (line 1017)
- `services/api-service/src/alerts/alerts.service.ts` → returns raw Prisma objects
- `services/api-service/src/copy/copy.service.ts` → returns raw Prisma objects

## Test plan

- [x] 203 tests pass (0 failures)
- [x] New tests: `TestAlertFields` (3 tests) — field names, no old fields, parse from API
- [x] Updated tests: `TestCopyConfigFields` (3 tests) — aligned with new field names
- [ ] Manual: verify `list_alerts()` works with raw array response
- [ ] Manual: verify `list_copy_configs()` works with raw array response

BREAKING CHANGE: `Alert` and `CopyConfig` field names have changed.

closes #107, closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)