### PR TITLE
fix(models): align StrategyTemplate with platform Strategy schema (closes #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.20] — 2026-04-14
+
+### Fixed
+- **BREAKING:** `StrategyTemplate` model: replaced phantom fields (`risk_level`, `category`, `config`) with full `Strategy` fields — `StrategyTemplate` is now an alias for `Strategy` since the platform returns full strategy objects from `GET /api/v1/strategies/templates` (closes #44)
+
 ## [1.6.19] — 2026-04-14
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -577,7 +577,7 @@ class PolyforgeClient:
 
     def get_strategy_templates(self) -> list[StrategyTemplate]:
         data = self._get("/api/v1/strategies/templates")
-        # Backend returns PaginatedResponse<StrategyTemplate> with 'data' field
+        # Backend returns PaginatedResponse<Strategy> with 'data' field
         items = data["data"]
         return [_parse(StrategyTemplate, t) for t in items]
 
@@ -1502,7 +1502,7 @@ class AsyncPolyforgeClient:
 
     async def get_strategy_templates(self) -> list[StrategyTemplate]:
         data = await self._get("/api/v1/strategies/templates")
-        # Backend returns PaginatedResponse<StrategyTemplate> with 'data' field
+        # Backend returns PaginatedResponse<Strategy> with 'data' field
         items = data["data"]
         return [_parse(StrategyTemplate, t) for t in items]
 

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -165,16 +165,10 @@ class StrategyStatusResponse:
     stopped_at: str = ""
 
 
-@dataclass
-class StrategyTemplate:
-    """A pre-built strategy template."""
-
-    id: str = ""
-    name: str = ""
-    description: str = ""
-    category: str = ""
-    risk_level: str = ""
-    config: dict[str, Any] = field(default_factory=dict)
+# StrategyTemplate is an alias for Strategy — the platform endpoint
+# ``GET /api/v1/strategies/templates`` returns full Strategy objects
+# (rows where ``template = true``).  Kept as an alias for backward compat.
+StrategyTemplate = Strategy
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -811,6 +811,79 @@ class TestStrategyBlockCategories:
         assert strategy.trade_count == 42
 
 
+class TestStrategyTemplateAlias:
+    """Tests for StrategyTemplate being an alias for Strategy (#44).
+
+    The platform endpoint ``GET /api/v1/strategies/templates`` returns full
+    Strategy objects (rows where ``template = true``).  The old StrategyTemplate
+    class had phantom fields (``risk_level``, ``config``, ``category``) that the
+    platform never sends; it now aliases Strategy so all real fields are parsed.
+    """
+
+    def test_strategy_template_is_strategy_alias(self):
+        """StrategyTemplate must be the same type as Strategy."""
+        from polyforge.models import StrategyTemplate
+        assert StrategyTemplate is Strategy
+
+    def test_template_parses_full_strategy_fields(self):
+        """Templates returned by the platform include full strategy data."""
+        from polyforge.models import StrategyTemplate
+        api_response = {
+            "id": "tmpl-1",
+            "name": "Momentum Alpha",
+            "description": "A momentum-based strategy template",
+            "status": "IDLE",
+            "template": True,
+            "triggers": [{"id": "t1", "type": "PRICE_THRESHOLD", "label": "Price > 0.7", "config": {"price": 0.7}}],
+            "conditions": [],
+            "actions": [{"id": "a1", "type": "PLACE_ORDER", "label": "Buy YES", "config": {}}],
+            "safety": [],
+            "visibility": "PUBLIC",
+            "execMode": "TICK",
+            "forkCount": 15,
+            "likeCount": 42,
+            "tags": ["momentum", "beginner"],
+            "version": 3,
+        }
+        template = _parse(StrategyTemplate, api_response)
+        assert template.id == "tmpl-1"
+        assert template.name == "Momentum Alpha"
+        assert len(template.triggers) == 1
+        assert template.triggers[0].type == "PRICE_THRESHOLD"
+        assert len(template.actions) == 1
+        assert template.visibility == "PUBLIC"
+        assert template.fork_count == 15
+        assert template.like_count == 42
+        assert template.tags == ["momentum", "beginner"]
+        assert template.version == 3
+
+    def test_template_backward_compat_import(self):
+        """StrategyTemplate is importable from polyforge and is Strategy."""
+        from polyforge import StrategyTemplate, Strategy
+        assert StrategyTemplate is Strategy
+
+    def test_old_phantom_fields_not_silently_accepted(self):
+        """Parsing a response with old phantom fields should not crash.
+
+        The platform never sends ``risk_level`` or ``category`` but
+        if a cached response or mock contains them, _parse drops them
+        gracefully via its unknown-field handling.
+        """
+        from polyforge.models import StrategyTemplate
+        api_response = {
+            "id": "tmpl-old",
+            "name": "Legacy",
+            "risk_level": "HIGH",  # phantom — platform doesn't send this
+            "category": "momentum",  # phantom
+            "config": {"foo": 1},  # phantom
+        }
+        template = _parse(StrategyTemplate, api_response)
+        assert template.id == "tmpl-old"
+        assert template.name == "Legacy"
+        # Strategy has no risk_level/category — they should be silently dropped
+        assert not hasattr(template, "risk_level") or template.status == ""
+
+
 class TestCreateStrategyParams:
     """Tests for create_strategy expanded parameters (#32)."""
 


### PR DESCRIPTION
## Summary
- **BREAKING:** `StrategyTemplate` is now an alias for `Strategy` — the platform's `GET /api/v1/strategies/templates` returns full Strategy objects (rows with `template=true`)
- Removed phantom fields `risk_level`, `category`, `config` that the platform never sends
- All real Strategy fields (triggers, conditions, actions, safety, visibility, tags, etc.) are now correctly parsed for templates
- 207 tests pass (4 new tests added)

## What changed
- `src/polyforge/models.py`: Replaced `StrategyTemplate` dataclass with `StrategyTemplate = Strategy` alias
- `src/polyforge/client.py`: Updated comments in `get_strategy_templates()` (both sync and async)
- `tests/test_client.py`: 4 new tests verifying alias behavior, field parsing, backward compat, and phantom field handling

## Verification
- Verified against platform source: `strategies.service.ts:listTemplates()` returns `PaginatedResponse<Strategy>` from Prisma
- Strategy model in Prisma has no `risk_level`, `category`, or flat `config` field
- The `blocks` arrays are `triggers`, `conditions`, `actions`, `safety` JSON fields on Strategy

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)