### PR TITLE
fix(client): return PaginatedResponse from list endpoints (closes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.7.0] — 2026-04-14
+
+### Changed
+- **BREAKING:** `list_strategies()` now returns `PaginatedResponse[Strategy]` instead of `list[Strategy]` — use `.data` to access the list (closes #105)
+- **BREAKING:** `get_orders()` now returns `PaginatedResponse[Order]` instead of `list[Order]` — use `.data` to access the list
+- **BREAKING:** `list_conditional_orders()` now returns `PaginatedResponse[ConditionalOrder]` instead of `list[ConditionalOrder]` — use `.data` to access the list
+
+### Added
+- `get_orders()`: added `page` and `market_id` parameters to match platform `OrderQueryDto`
+- `list_conditional_orders()`: added `type` and `page` parameters to match platform `ConditionalOrderQueryDto`
+
 ## [1.6.20] — 2026-04-14
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -482,14 +482,19 @@ class PolyforgeClient:
         sort: str | None = None,
         page: int = 1,
         limit: int = 20,
-    ) -> list[Strategy]:
-        data = self._get(
+    ) -> PaginatedResponse[Strategy]:
+        raw = self._get(
             "/api/v1/strategies",
             params={"status": status, "sort": sort, "page": page, "limit": limit},
         )
-        # Backend returns PaginatedResponse<Strategy> with 'data' field
-        items = data["data"]
-        return [_parse(Strategy, s) for s in items]
+        return PaginatedResponse(
+            data=[_parse(Strategy, s) for s in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     def get_strategy(self, strategy_id: str) -> Strategy:
         return _parse(Strategy, self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}"))
@@ -654,11 +659,13 @@ class PolyforgeClient:
         self,
         *,
         limit: int = 20,
+        page: int = 1,
         status: str | OrderStatus | None = None,
         strategy_id: str | None = None,
+        market_id: str | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
-    ) -> list[Order]:
+    ) -> PaginatedResponse[Order]:
         """List orders with optional filters.
 
         Args:
@@ -668,15 +675,23 @@ class PolyforgeClient:
                 ``UNMATCHED``, ``FAILED``, ``ERROR``.
         """
         status_val = status.value if isinstance(status, OrderStatus) else status
-        data = self._get("/api/v1/orders", params={
+        raw = self._get("/api/v1/orders", params={
             "limit": limit,
+            "page": page,
             "status": status_val,
             "strategyId": strategy_id,
+            "marketId": market_id,
             "from": from_date,
             "to": to_date,
         })
-        items = data["data"]
-        return [_parse(Order, o) for o in items]
+        return PaginatedResponse(
+            data=[_parse(Order, o) for o in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     def get_score(self) -> TraderScore:
         return _parse(TraderScore, self._get("/api/v1/scores/me"))
@@ -997,18 +1012,32 @@ class PolyforgeClient:
         self,
         *,
         status: str | None = None,
-        limit: int | None = None,
-    ) -> list[ConditionalOrder]:
+        type: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedResponse[ConditionalOrder]:
         """List conditional orders with optional filters.
 
         Args:
             status: Filter by status (e.g. ``"PENDING"``, ``"TRIGGERED"``).
-            limit: Maximum number of results.
+            type: Filter by type (e.g. ``"TAKE_PROFIT"``, ``"STOP_LOSS"``).
+            page: Page number (default 1).
+            limit: Maximum number of results per page (default 20).
         """
-        params = _strip_none({"status": status, "limit": limit})
-        data = self._get("/api/v1/orders/conditional", params=params)
-        items = data["data"]
-        return [_parse(ConditionalOrder, o) for o in items]
+        raw = self._get("/api/v1/orders/conditional", params={
+            "status": status,
+            "type": type,
+            "page": page,
+            "limit": limit,
+        })
+        return PaginatedResponse(
+            data=[_parse(ConditionalOrder, o) for o in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     def create_conditional_order(
         self,
@@ -1425,14 +1454,19 @@ class AsyncPolyforgeClient:
         sort: str | None = None,
         page: int = 1,
         limit: int = 20,
-    ) -> list[Strategy]:
-        data = await self._get(
+    ) -> PaginatedResponse[Strategy]:
+        raw = await self._get(
             "/api/v1/strategies",
             params={"status": status, "sort": sort, "page": page, "limit": limit},
         )
-        # Backend returns PaginatedResponse<Strategy> with 'data' field
-        items = data["data"]
-        return [_parse(Strategy, s) for s in items]
+        return PaginatedResponse(
+            data=[_parse(Strategy, s) for s in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     async def get_strategy(self, strategy_id: str) -> Strategy:
         return _parse(Strategy, await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}"))
@@ -1579,22 +1613,32 @@ class AsyncPolyforgeClient:
         self,
         *,
         limit: int = 20,
+        page: int = 1,
         status: str | OrderStatus | None = None,
         strategy_id: str | None = None,
+        market_id: str | None = None,
         from_date: str | None = None,
         to_date: str | None = None,
-    ) -> list[Order]:
+    ) -> PaginatedResponse[Order]:
         """List orders with optional filters (async version)."""
         status_val = status.value if isinstance(status, OrderStatus) else status
-        data = await self._get("/api/v1/orders", params={
+        raw = await self._get("/api/v1/orders", params={
             "limit": limit,
+            "page": page,
             "status": status_val,
             "strategyId": strategy_id,
+            "marketId": market_id,
             "from": from_date,
             "to": to_date,
         })
-        items = data["data"]
-        return [_parse(Order, o) for o in items]
+        return PaginatedResponse(
+            data=[_parse(Order, o) for o in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     async def get_score(self) -> TraderScore:
         return _parse(TraderScore, await self._get("/api/v1/scores/me"))
@@ -1908,18 +1952,32 @@ class AsyncPolyforgeClient:
         self,
         *,
         status: str | None = None,
-        limit: int | None = None,
-    ) -> list[ConditionalOrder]:
+        type: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedResponse[ConditionalOrder]:
         """List conditional orders with optional filters.
 
         Args:
             status: Filter by status (e.g. ``"PENDING"``, ``"TRIGGERED"``).
-            limit: Maximum number of results.
+            type: Filter by type (e.g. ``"TAKE_PROFIT"``, ``"STOP_LOSS"``).
+            page: Page number (default 1).
+            limit: Maximum number of results per page (default 20).
         """
-        params = _strip_none({"status": status, "limit": limit})
-        data = await self._get("/api/v1/orders/conditional", params=params)
-        items = data["data"]
-        return [_parse(ConditionalOrder, o) for o in items]
+        raw = await self._get("/api/v1/orders/conditional", params={
+            "status": status,
+            "type": type,
+            "page": page,
+            "limit": limit,
+        })
+        return PaginatedResponse(
+            data=[_parse(ConditionalOrder, o) for o in raw["data"]],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
 
     async def create_conditional_order(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1998,3 +1998,82 @@ class TestPortfolioPnl:
         sig = inspect.signature(PolyforgeClient.get_portfolio_pnl)
         ret = sig.return_annotation
         assert "PortfolioPnl" in str(ret)
+
+
+class TestPaginatedResponses:
+    """Tests for #105 — list endpoints returning PaginatedResponse."""
+
+    def test_list_strategies_returns_paginated_response(self):
+        """list_strategies() must return PaginatedResponse[Strategy]."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_strategies)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_get_orders_returns_paginated_response(self):
+        """get_orders() must return PaginatedResponse[Order]."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.get_orders)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_list_conditional_orders_returns_paginated_response(self):
+        """list_conditional_orders() must return PaginatedResponse[ConditionalOrder]."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_conditional_orders)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_async_list_strategies_returns_paginated_response(self):
+        """Async list_strategies() must return PaginatedResponse[Strategy]."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.list_strategies)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_async_get_orders_returns_paginated_response(self):
+        """Async get_orders() must return PaginatedResponse[Order]."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.get_orders)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_async_list_conditional_orders_returns_paginated_response(self):
+        """Async list_conditional_orders() must return PaginatedResponse[ConditionalOrder]."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.list_conditional_orders)
+        ret = str(sig.return_annotation)
+        assert "PaginatedResponse" in ret, f"Expected PaginatedResponse, got {ret}"
+
+    def test_get_orders_accepts_page_and_market_id(self):
+        """get_orders() must accept page and market_id params."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.get_orders)
+        param_names = set(sig.parameters.keys())
+        assert "page" in param_names, "get_orders() missing 'page' parameter"
+        assert "market_id" in param_names, "get_orders() missing 'market_id' parameter"
+
+    def test_list_conditional_orders_accepts_type_and_page(self):
+        """list_conditional_orders() must accept type and page params."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_conditional_orders)
+        param_names = set(sig.parameters.keys())
+        assert "type" in param_names, "list_conditional_orders() missing 'type' parameter"
+        assert "page" in param_names, "list_conditional_orders() missing 'page' parameter"
+
+    def test_list_strategies_source_builds_paginated_response(self):
+        """list_strategies() must construct PaginatedResponse from raw API data."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.list_strategies)
+        assert "PaginatedResponse(" in source
+        assert 'raw["total"]' in source or "raw['total']" in source
+        assert 'raw["hasNext"]' in source or "raw['hasNext']" in source


### PR DESCRIPTION
## Summary
- **BREAKING:** `list_strategies()`, `get_orders()`, `list_conditional_orders()` now return `PaginatedResponse[T]` instead of `list[T]`
- Added missing query params: `page` + `market_id` for `get_orders()`, `type` + `page` for `list_conditional_orders()`
- Both sync and async clients updated
- Verified against platform source: only 3 endpoints actually return `PaginatedResponse` — alerts, copy configs, webhooks, whales, news, and smart orders correctly remain as `list[T]`
- 216 tests pass (9 new)

## Migration
```python
# Before
orders = client.get_orders()
for order in orders: ...

# After
result = client.get_orders()
for order in result.data: ...
print(f"Page {result.page} of {result.total_pages}")
```

## Test plan
- [x] All 216 tests pass
- [x] Return types verified via signature inspection
- [x] Source code assertions verify PaginatedResponse construction

closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)