### PR TITLE
feat(client): add backtest list/get/quick/orders methods (closes #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.8.0] — 2026-04-14
+
+### Added
+- `list_backtests(strategy_id, status, page, limit)` — list backtests with pagination and filters (closes #73)
+- `get_backtest(backtest_id)` — fetch a single backtest by ID (closes #73)
+- `run_quick_backtest(...)` — run a quick backtest via `/api/v1/backtests/quick` (closes #73)
+- `get_backtest_orders(backtest_id)` — fetch orders generated during a backtest (closes #73)
+- All four methods added to both `PolyforgeClient` and `AsyncPolyforgeClient`
+
 ## [1.7.0] — 2026-04-14
 
 ### Changed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -650,6 +650,96 @@ class PolyforgeClient:
             body["marketBindings"] = market_bindings
         return self._post("/api/v1/backtests", json=body)
 
+    def list_backtests(
+        self,
+        *,
+        strategy_id: str | None = None,
+        status: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List backtests with optional filters.
+
+        Args:
+            strategy_id: Filter by strategy ID.
+            status: Filter by backtest status.
+            page: Page number (default 1).
+            limit: Items per page (default 20, max 100).
+
+        Returns:
+            Paginated list of backtest dicts.
+        """
+        raw = self._get(
+            "/api/v1/backtests",
+            params={"strategyId": strategy_id, "status": status, "page": page, "limit": limit},
+        )
+        return PaginatedResponse(
+            data=raw["data"],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
+
+    def get_backtest(self, backtest_id: str) -> dict[str, Any]:
+        """Get a single backtest by ID.
+
+        Args:
+            backtest_id: The backtest ID.
+
+        Returns:
+            Raw backtest dict from the platform.
+        """
+        return self._get(f"/api/v1/backtests/{_encode_path(backtest_id)}")
+
+    def run_quick_backtest(
+        self,
+        strategy_id: str,
+        *,
+        date_range_start: str | None = None,
+        date_range_end: str | None = None,
+        quick_mode: bool | None = None,
+        strategy_blocks: dict[str, Any] | None = None,
+        market_bindings: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Run a quick backtest for a strategy.
+
+        Args:
+            strategy_id: ID of the strategy to backtest.
+            date_range_start: ISO 8601 start of the date range.
+            date_range_end: ISO 8601 end of the date range.
+            quick_mode: If True, run a fast approximate backtest.
+            strategy_blocks: Optional override for strategy block config.
+            market_bindings: Optional market binding overrides.
+
+        Returns:
+            Raw backtest result dict from the platform.
+        """
+        body: dict[str, Any] = {"strategyId": strategy_id}
+        if date_range_start is not None:
+            body["dateRangeStart"] = date_range_start
+        if date_range_end is not None:
+            body["dateRangeEnd"] = date_range_end
+        if quick_mode is not None:
+            body["quickMode"] = quick_mode
+        if strategy_blocks is not None:
+            body["strategyBlocks"] = strategy_blocks
+        if market_bindings is not None:
+            body["marketBindings"] = market_bindings
+        return self._post("/api/v1/backtests/quick", json=body)
+
+    def get_backtest_orders(self, backtest_id: str) -> list[dict[str, Any]]:
+        """Get orders generated during a backtest.
+
+        Args:
+            backtest_id: The backtest ID.
+
+        Returns:
+            List of order dicts from the backtest.
+        """
+        return self._get(f"/api/v1/backtests/{_encode_path(backtest_id)}/orders")
+
     # -- Portfolio & Orders --
 
     def get_portfolio(self) -> Portfolio:
@@ -1603,6 +1693,96 @@ class AsyncPolyforgeClient:
         if market_bindings is not None:
             body["marketBindings"] = market_bindings
         return await self._post("/api/v1/backtests", json=body)
+
+    async def list_backtests(
+        self,
+        *,
+        strategy_id: str | None = None,
+        status: str | None = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List backtests with optional filters (async version).
+
+        Args:
+            strategy_id: Filter by strategy ID.
+            status: Filter by backtest status.
+            page: Page number (default 1).
+            limit: Items per page (default 20, max 100).
+
+        Returns:
+            Paginated list of backtest dicts.
+        """
+        raw = await self._get(
+            "/api/v1/backtests",
+            params={"strategyId": strategy_id, "status": status, "page": page, "limit": limit},
+        )
+        return PaginatedResponse(
+            data=raw["data"],
+            total=raw["total"],
+            page=raw["page"],
+            limit=raw["limit"],
+            has_more=raw["hasNext"],
+            total_pages=raw.get("totalPages", 0),
+        )
+
+    async def get_backtest(self, backtest_id: str) -> dict[str, Any]:
+        """Get a single backtest by ID (async version).
+
+        Args:
+            backtest_id: The backtest ID.
+
+        Returns:
+            Raw backtest dict from the platform.
+        """
+        return await self._get(f"/api/v1/backtests/{_encode_path(backtest_id)}")
+
+    async def run_quick_backtest(
+        self,
+        strategy_id: str,
+        *,
+        date_range_start: str | None = None,
+        date_range_end: str | None = None,
+        quick_mode: bool | None = None,
+        strategy_blocks: dict[str, Any] | None = None,
+        market_bindings: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Run a quick backtest for a strategy (async version).
+
+        Args:
+            strategy_id: ID of the strategy to backtest.
+            date_range_start: ISO 8601 start of the date range.
+            date_range_end: ISO 8601 end of the date range.
+            quick_mode: If True, run a fast approximate backtest.
+            strategy_blocks: Optional override for strategy block config.
+            market_bindings: Optional market binding overrides.
+
+        Returns:
+            Raw backtest result dict from the platform.
+        """
+        body: dict[str, Any] = {"strategyId": strategy_id}
+        if date_range_start is not None:
+            body["dateRangeStart"] = date_range_start
+        if date_range_end is not None:
+            body["dateRangeEnd"] = date_range_end
+        if quick_mode is not None:
+            body["quickMode"] = quick_mode
+        if strategy_blocks is not None:
+            body["strategyBlocks"] = strategy_blocks
+        if market_bindings is not None:
+            body["marketBindings"] = market_bindings
+        return await self._post("/api/v1/backtests/quick", json=body)
+
+    async def get_backtest_orders(self, backtest_id: str) -> list[dict[str, Any]]:
+        """Get orders generated during a backtest (async version).
+
+        Args:
+            backtest_id: The backtest ID.
+
+        Returns:
+            List of order dicts from the backtest.
+        """
+        return await self._get(f"/api/v1/backtests/{_encode_path(backtest_id)}/orders")
 
     # -- Portfolio & Orders --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2077,3 +2077,128 @@ class TestPaginatedResponses:
         assert "PaginatedResponse(" in source
         assert 'raw["total"]' in source or "raw['total']" in source
         assert 'raw["hasNext"]' in source or "raw['hasNext']" in source
+
+
+class TestBacktestMethods:
+    """Tests for backtest list/get/quick/orders methods (#73)."""
+
+    # -- Signature tests (sync) --
+
+    def test_list_backtests_signature(self):
+        """list_backtests() must accept strategy_id, status, page, limit."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.list_backtests)
+        param_names = set(sig.parameters.keys())
+        assert "strategy_id" in param_names
+        assert "status" in param_names
+        assert "page" in param_names
+        assert "limit" in param_names
+
+    def test_get_backtest_signature(self):
+        """get_backtest() must accept backtest_id."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.get_backtest)
+        param_names = set(sig.parameters.keys())
+        assert "backtest_id" in param_names
+
+    def test_run_quick_backtest_signature(self):
+        """run_quick_backtest() must accept same params as run_backtest."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.run_quick_backtest)
+        param_names = set(sig.parameters.keys())
+        assert "strategy_id" in param_names
+        assert "date_range_start" in param_names
+        assert "date_range_end" in param_names
+
+    def test_get_backtest_orders_signature(self):
+        """get_backtest_orders() must accept backtest_id."""
+        import inspect
+
+        sig = inspect.signature(PolyforgeClient.get_backtest_orders)
+        param_names = set(sig.parameters.keys())
+        assert "backtest_id" in param_names
+
+    # -- Signature tests (async) --
+
+    def test_async_list_backtests_signature(self):
+        """AsyncPolyforgeClient.list_backtests() must accept strategy_id, status, page, limit."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.list_backtests)
+        param_names = set(sig.parameters.keys())
+        assert "strategy_id" in param_names
+        assert "status" in param_names
+        assert "page" in param_names
+        assert "limit" in param_names
+
+    def test_async_get_backtest_signature(self):
+        """AsyncPolyforgeClient.get_backtest() must accept backtest_id."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.get_backtest)
+        param_names = set(sig.parameters.keys())
+        assert "backtest_id" in param_names
+
+    def test_async_run_quick_backtest_signature(self):
+        """AsyncPolyforgeClient.run_quick_backtest() must accept same params as run_backtest."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.run_quick_backtest)
+        param_names = set(sig.parameters.keys())
+        assert "strategy_id" in param_names
+        assert "date_range_start" in param_names
+        assert "date_range_end" in param_names
+
+    def test_async_get_backtest_orders_signature(self):
+        """AsyncPolyforgeClient.get_backtest_orders() must accept backtest_id."""
+        import inspect
+
+        sig = inspect.signature(AsyncPolyforgeClient.get_backtest_orders)
+        param_names = set(sig.parameters.keys())
+        assert "backtest_id" in param_names
+
+    # -- Source inspection tests --
+
+    def test_list_backtests_builds_paginated_response(self):
+        """list_backtests() must construct PaginatedResponse from raw API data."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.list_backtests)
+        assert "PaginatedResponse(" in source
+        assert 'raw["total"]' in source or "raw['total']" in source
+        assert 'raw["hasNext"]' in source or "raw['hasNext']" in source
+
+    def test_list_backtests_passes_query_params(self):
+        """list_backtests() must pass strategyId and status to the HTTP params."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.list_backtests)
+        assert '"strategyId"' in source or "'strategyId'" in source
+        assert '"status"' in source or "'status'" in source
+        assert '"page"' in source or "'page'" in source
+        assert '"limit"' in source or "'limit'" in source
+
+    def test_run_quick_backtest_posts_to_quick_endpoint(self):
+        """run_quick_backtest() must POST to /api/v1/backtests/quick."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.run_quick_backtest)
+        assert "/api/v1/backtests/quick" in source
+
+    def test_get_backtest_uses_encode_path(self):
+        """get_backtest() must use _encode_path for the backtest_id."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.get_backtest)
+        assert "_encode_path" in source
+
+    def test_get_backtest_orders_uses_encode_path(self):
+        """get_backtest_orders() must use _encode_path for the backtest_id."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.get_backtest_orders)
+        assert "_encode_path" in source
+        assert "/orders" in source


### PR DESCRIPTION
## Summary
- Add `list_backtests()`, `get_backtest()`, `run_quick_backtest()`, and `get_backtest_orders()` to both `PolyforgeClient` and `AsyncPolyforgeClient`
- Methods follow existing patterns: `_encode_path()` for path params, query param dicts for filters, `PaginatedResponse` for list endpoints
- 13 new tests added (229 total, all passing)

## Endpoints covered
| Method | HTTP | Endpoint |
|--------|------|----------|
| `list_backtests()` | GET | `/api/v1/backtests` |
| `get_backtest()` | GET | `/api/v1/backtests/:id` |
| `run_quick_backtest()` | POST | `/api/v1/backtests/quick` |
| `get_backtest_orders()` | GET | `/api/v1/backtests/:id/orders` |

## Test plan
- [x] All 229 tests pass (`python3 -m pytest tests/ -v`)
- [x] No new ruff lint errors introduced
- [x] mypy: no new errors (1 pre-existing on line 293)
- [x] CHANGELOG.md updated

Closes #73