### PR TITLE
fix(security): add runtime validation for enum-like parameters (closes #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.9.0] — 2026-04-14
+
+### Added
+- Runtime validation for enum-like string parameters via `_validate_enum()` helper (closes #41)
+  - `start_strategy(mode=)` now rejects values other than `"live"` / `"paper"`
+  - `place_order(side=, outcome=, order_type=)` now rejects invalid values before HTTP call
+  - Applied to both `PolyforgeClient` and `AsyncPolyforgeClient`
+
 ## [1.8.0] — 2026-04-14
 
 ### Added

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -202,6 +202,23 @@ def _encode_path(segment: str) -> str:
     return quote(str(segment), safe="")
 
 
+def _validate_enum(name: str, value: str, allowed: frozenset[str]) -> None:
+    """Reject values not in *allowed* for enum-like string parameters.
+
+    Raises:
+        ValueError: if *value* is not in *allowed*.
+    """
+    if value not in allowed:
+        sorted_opts = ", ".join(sorted(allowed))
+        raise ValueError(f"{name} must be one of {{{sorted_opts}}}, got {value!r}")
+
+
+_VALID_MODES = frozenset({"live", "paper"})
+_VALID_SIDES = frozenset({"BUY", "SELL"})
+_VALID_OUTCOMES = frozenset({"YES", "NO"})
+_VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "FAK"})
+
+
 def _validate_financial_param(name: str, value: float) -> None:
     """Reject NaN, Infinity, negative, and zero values for financial parameters.
 
@@ -575,6 +592,7 @@ class PolyforgeClient:
         return _parse(Strategy, self._post("/api/v1/strategies/from-description", json=body))
 
     def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
+        _validate_enum("mode", mode, _VALID_MODES)
         return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
@@ -798,6 +816,9 @@ class PolyforgeClient:
         order_type: str = "GTC",
     ) -> PlaceOrderResponse:
         """Place a direct buy or sell order on a prediction market."""
+        _validate_enum("side", side, _VALID_SIDES)
+        _validate_enum("outcome", outcome, _VALID_OUTCOMES)
+        _validate_enum("order_type", order_type, _VALID_ORDER_TYPES)
         _validate_financial_param("size", size)
         _validate_financial_param("price", price)
         data = self._post("/api/v1/orders/place", json={
@@ -1619,6 +1640,7 @@ class AsyncPolyforgeClient:
         return _parse(Strategy, await self._post("/api/v1/strategies/from-description", json=body))
 
     async def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
+        _validate_enum("mode", mode, _VALID_MODES)
         return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     async def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
@@ -1835,6 +1857,9 @@ class AsyncPolyforgeClient:
         order_type: str = "GTC",
     ) -> PlaceOrderResponse:
         """Place a direct buy or sell order on a prediction market."""
+        _validate_enum("side", side, _VALID_SIDES)
+        _validate_enum("outcome", outcome, _VALID_OUTCOMES)
+        _validate_enum("order_type", order_type, _VALID_ORDER_TYPES)
         _validate_financial_param("size", size)
         _validate_financial_param("price", price)
         data = await self._post("/api/v1/orders/place", json={

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from polyforge.client import (
     AsyncPolyforgeClient,
     _parse,
     _raise_for_status,
+    _validate_enum,
     _validate_financial_param,
     _validate_webhook_url,
     _is_ip_blocked,
@@ -659,6 +660,42 @@ class TestFinancialParamValidation:
 
     def test_accepts_positive_int(self):
         _validate_financial_param("size", 10)  # should not raise
+
+
+class TestEnumValidation:
+    """Ensure _validate_enum rejects invalid enum values (#41)."""
+
+    def test_rejects_invalid_mode(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            _validate_enum("mode", "turbo", frozenset({"live", "paper"}))
+
+    def test_accepts_valid_mode(self):
+        _validate_enum("mode", "paper", frozenset({"live", "paper"}))  # should not raise
+        _validate_enum("mode", "live", frozenset({"live", "paper"}))
+
+    def test_rejects_invalid_side(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            _validate_enum("side", "HOLD", frozenset({"BUY", "SELL"}))
+
+    def test_start_strategy_rejects_invalid_mode(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be one of"):
+            client.start_strategy("s-1", mode="turbo")
+
+    def test_place_order_rejects_invalid_side(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be one of"):
+            client.place_order("tok", "HOLD", "YES", 10.0, 0.5)
+
+    def test_place_order_rejects_invalid_outcome(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be one of"):
+            client.place_order("tok", "BUY", "MAYBE", 10.0, 0.5)
+
+    def test_place_order_rejects_invalid_order_type(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="must be one of"):
+            client.place_order("tok", "BUY", "YES", 10.0, 0.5, order_type="IOC")
 
 
 class TestPlaceOrderValidation:


### PR DESCRIPTION
## Summary
- Adds `_validate_enum()` helper for client-side validation of enum-like string parameters
- `start_strategy(mode=)` now validates against `{"live", "paper"}`
- `place_order(side=, outcome=, order_type=)` now validates against valid values before HTTP round-trip
- Applied to both sync `PolyforgeClient` and `AsyncPolyforgeClient`
- 7 new tests (236 total), matching the pattern established by `_validate_financial_param`

## Problem
The Python SDK accepted arbitrary strings for `mode`, `side`, `outcome`, and `order_type` parameters. Unlike the TypeScript SDK (compile-time types) and MCP server (zod validation), invalid values only failed after a network round-trip with an opaque API error.

closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)