### PR TITLE
fix(compat): use correct `period` param for get_price_history (closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.9.2] — 2026-04-15
+
+### Fixed
+- **Price history params** — `get_price_history()` now sends `period` (with values `"1h"`, `"6h"`, `"24h"`) instead of the incorrect `resolution` parameter. Removed unsupported `from_date`/`to_date` params that were silently ignored by the platform. (closes #116)
+
 ## [1.9.1] — 2026-04-15
 
 ### Security

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -455,26 +455,20 @@ class PolyforgeClient:
         self,
         token_id: str,
         *,
-        resolution: str | None = None,
-        from_date: str | None = None,
-        to_date: str | None = None,
+        period: str | None = None,
         limit: int | None = None,
     ) -> list[PriceHistoryEntry]:
         """Fetch price history for a market token.
 
         Args:
             token_id: The token ID to fetch history for.
-            resolution: Candle resolution — ``"1m"``, ``"1h"``, or ``"1d"`` (default ``"1h"``).
-            from_date: Start time as ISO 8601 string.
-            to_date: End time as ISO 8601 string.
-            limit: Maximum number of entries (1–1000, default 200).
+            period: Candle period — ``"1h"``, ``"6h"``, or ``"24h"`` (default ``"1h"``).
+            limit: Maximum number of entries (1–500, default server-side).
         """
         data = self._get(
             f"/api/v1/markets/{_encode_path(token_id)}/price-history",
             params={
-                "resolution": resolution,
-                "from": from_date,
-                "to": to_date,
+                "period": period,
                 "limit": limit,
             },
         )
@@ -1521,26 +1515,20 @@ class AsyncPolyforgeClient:
         self,
         token_id: str,
         *,
-        resolution: str | None = None,
-        from_date: str | None = None,
-        to_date: str | None = None,
+        period: str | None = None,
         limit: int | None = None,
     ) -> list[PriceHistoryEntry]:
         """Fetch price history for a market token.
 
         Args:
             token_id: The token ID to fetch history for.
-            resolution: Candle resolution — ``"1m"``, ``"1h"``, or ``"1d"`` (default ``"1h"``).
-            from_date: Start time as ISO 8601 string.
-            to_date: End time as ISO 8601 string.
-            limit: Maximum number of entries (1–1000, default 200).
+            period: Candle period — ``"1h"``, ``"6h"``, or ``"24h"`` (default ``"1h"``).
+            limit: Maximum number of entries (1–500, default server-side).
         """
         data = await self._get(
             f"/api/v1/markets/{_encode_path(token_id)}/price-history",
             params={
-                "resolution": resolution,
-                "from": from_date,
-                "to": to_date,
+                "period": period,
                 "limit": limit,
             },
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1616,15 +1616,13 @@ class TestGetPriceHistory:
     """Tests for get_price_history() method (#51)."""
 
     def test_get_price_history_accepts_all_params(self):
-        """get_price_history() signature must accept token_id, resolution, from_date, to_date, limit."""
+        """get_price_history() signature must accept token_id, period, limit."""
         import inspect
 
         sig = inspect.signature(PolyforgeClient.get_price_history)
         param_names = set(sig.parameters.keys())
         assert "token_id" in param_names, "get_price_history() missing 'token_id' parameter"
-        assert "resolution" in param_names, "get_price_history() missing 'resolution' parameter"
-        assert "from_date" in param_names, "get_price_history() missing 'from_date' parameter"
-        assert "to_date" in param_names, "get_price_history() missing 'to_date' parameter"
+        assert "period" in param_names, "get_price_history() missing 'period' parameter"
         assert "limit" in param_names, "get_price_history() missing 'limit' parameter"
 
     def test_async_get_price_history_accepts_all_params(self):
@@ -1634,9 +1632,7 @@ class TestGetPriceHistory:
         sig = inspect.signature(AsyncPolyforgeClient.get_price_history)
         param_names = set(sig.parameters.keys())
         assert "token_id" in param_names
-        assert "resolution" in param_names
-        assert "from_date" in param_names
-        assert "to_date" in param_names
+        assert "period" in param_names
         assert "limit" in param_names
 
     def test_get_price_history_uses_correct_path(self):
@@ -1648,13 +1644,11 @@ class TestGetPriceHistory:
         assert "/api/v1/markets/" in source
 
     def test_get_price_history_passes_query_params(self):
-        """get_price_history() must pass resolution, from, to, limit as query params."""
+        """get_price_history() must pass period, limit as query params."""
         import inspect
 
         source = inspect.getsource(PolyforgeClient.get_price_history)
-        assert '"resolution"' in source or "'resolution'" in source
-        assert '"from"' in source or "'from'" in source
-        assert '"to"' in source or "'to'" in source
+        assert '"period"' in source or "'period'" in source
         assert '"limit"' in source or "'limit'" in source
 
     def test_get_price_history_uses_path_encoding(self):


### PR DESCRIPTION
## Summary

- Renamed `resolution` → `period` in both sync and async `get_price_history()` methods
- Updated docstring values from `"1m"/"1h"/"1d"` to `"1h"/"6h"/"24h"` to match platform's `PriceHistoryQueryDto`
- Removed unsupported `from_date`/`to_date` parameters (platform silently strips them via whitelist validation pipe)
- Updated tests to verify correct parameter names

## Impact

Every `get_price_history()` call using `resolution` was silently falling back to the platform's default period. Users were getting unexpected OHLCV data with no error.

## Test plan

- [x] All 236 existing tests pass
- [x] Parameter signature tests updated for `period` instead of `resolution`
- [x] Query param source inspection tests updated

closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)