### PR TITLE
feat(compat): add export_orders_csv and export_portfolio_csv methods (closes #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.9.3] — 2026-04-15
+
+### Added
+- `export_orders_csv()` — download order history as CSV text via `GET /api/v1/orders/export/csv` (closes #117)
+- `export_portfolio_csv()` — download portfolio as CSV text via `GET /api/v1/portfolio/export/csv` (closes #117)
+- Both methods available on `PolyforgeClient` (sync) and `AsyncPolyforgeClient` (async)
+
 ## [1.9.2] — 2026-04-15
 
 ### Fixed

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -415,6 +415,11 @@ class PolyforgeClient:
             return None
         return resp.json()
 
+    def _get_text(self, path: str, *, params: dict[str, Any] | None = None) -> str:
+        resp = self._client.get(path, params=_strip_none(params or {}))
+        _raise_for_status(resp)
+        return resp.text
+
     # -- Markets --
 
     def list_markets(
@@ -797,6 +802,16 @@ class PolyforgeClient:
 
     def get_score(self) -> TraderScore:
         return _parse(TraderScore, self._get("/api/v1/scores/me"))
+
+    # -- CSV Exports --
+
+    def export_orders_csv(self) -> str:
+        """Download order history as CSV text."""
+        return self._get_text("/api/v1/orders/export/csv")
+
+    def export_portfolio_csv(self) -> str:
+        """Download portfolio as CSV text."""
+        return self._get_text("/api/v1/portfolio/export/csv")
 
     # -- Direct Trading --
 
@@ -1475,6 +1490,11 @@ class AsyncPolyforgeClient:
             return None
         return resp.json()
 
+    async def _get_text(self, path: str, *, params: dict[str, Any] | None = None) -> str:
+        resp = await self._client.get(path, params=_strip_none(params or {}))
+        _raise_for_status(resp)
+        return resp.text
+
     # -- Markets --
 
     async def list_markets(
@@ -1832,6 +1852,16 @@ class AsyncPolyforgeClient:
 
     async def get_score(self) -> TraderScore:
         return _parse(TraderScore, await self._get("/api/v1/scores/me"))
+
+    # -- CSV Exports --
+
+    async def export_orders_csv(self) -> str:
+        """Download order history as CSV text."""
+        return await self._get_text("/api/v1/orders/export/csv")
+
+    async def export_portfolio_csv(self) -> str:
+        """Download portfolio as CSV text."""
+        return await self._get_text("/api/v1/portfolio/export/csv")
 
     # -- Direct Trading --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2233,3 +2233,43 @@ class TestBacktestMethods:
         source = inspect.getsource(PolyforgeClient.get_backtest_orders)
         assert "_encode_path" in source
         assert "/orders" in source
+
+    # -- CSV Export --
+
+    def test_sync_export_orders_csv_exists(self):
+        assert callable(getattr(PolyforgeClient, "export_orders_csv", None))
+
+    def test_sync_export_portfolio_csv_exists(self):
+        assert callable(getattr(PolyforgeClient, "export_portfolio_csv", None))
+
+    def test_async_export_orders_csv_exists(self):
+        assert callable(getattr(AsyncPolyforgeClient, "export_orders_csv", None))
+
+    def test_async_export_portfolio_csv_exists(self):
+        assert callable(getattr(AsyncPolyforgeClient, "export_portfolio_csv", None))
+
+    def test_sync_export_orders_csv_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.export_orders_csv)
+        assert "/api/v1/orders/export/csv" in source
+
+    def test_sync_export_portfolio_csv_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.export_portfolio_csv)
+        assert "/api/v1/portfolio/export/csv" in source
+
+    def test_sync_export_orders_csv_returns_str(self):
+        import inspect
+        sig = inspect.signature(PolyforgeClient.export_orders_csv)
+        assert sig.return_annotation in (str, "str")
+
+    def test_sync_export_portfolio_csv_returns_str(self):
+        import inspect
+        sig = inspect.signature(PolyforgeClient.export_portfolio_csv)
+        assert sig.return_annotation in (str, "str")
+
+    def test_sync_get_text_helper_exists(self):
+        assert callable(getattr(PolyforgeClient, "_get_text", None))
+
+    def test_async_get_text_helper_exists(self):
+        assert callable(getattr(AsyncPolyforgeClient, "_get_text", None))


### PR DESCRIPTION
## Summary
- Add `export_orders_csv()` and `export_portfolio_csv()` to both sync and async clients
- New `_get_text` helper returns raw text instead of JSON for CSV endpoints
- Achieves feature parity with TypeScript SDK's `exportOrdersCsv()` and `exportPortfolioCsv()`
- 246 tests pass (10 new tests added)

## Test plan
- [x] `test_sync_export_orders_csv_exists` — method exists on sync client
- [x] `test_sync_export_portfolio_csv_exists` — method exists on sync client
- [x] `test_async_export_orders_csv_exists` — method exists on async client
- [x] `test_async_export_portfolio_csv_exists` — method exists on async client
- [x] `test_sync_export_orders_csv_uses_correct_path` — verifies API path
- [x] `test_sync_export_portfolio_csv_uses_correct_path` — verifies API path
- [x] `test_sync_export_orders_csv_returns_str` — return type annotation
- [x] `test_sync_export_portfolio_csv_returns_str` — return type annotation
- [x] `test_sync_get_text_helper_exists` — _get_text helper exists
- [x] `test_async_get_text_helper_exists` — async _get_text helper exists

closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)