### PR TITLE
fix(security): remove plain-text API key from instance attributes (POLA-354)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -379,7 +379,6 @@ class PolyforgeClient:
         api_url: str = "https://api.polyforge.app",
         timeout: float = 15.0,
     ) -> None:
-        self._api_key = api_key
         self._api_url = api_url.rstrip("/")
 
         # Reject non-HTTPS URLs for non-localhost hosts
@@ -400,6 +399,11 @@ class PolyforgeClient:
 
     def __repr__(self) -> str:
         return f"PolyforgeClient(api_key='[REDACTED]', base_url='{self._api_url}')"
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_client", None)
+        return state
 
     # -- helpers --
 
@@ -1945,7 +1949,6 @@ class AsyncPolyforgeClient:
         api_url: str = "https://api.polyforge.app",
         timeout: float = 15.0,
     ) -> None:
-        self._api_key = api_key
         self._api_url = api_url.rstrip("/")
 
         # Reject non-HTTPS URLs for non-localhost hosts
@@ -1966,6 +1969,11 @@ class AsyncPolyforgeClient:
 
     def __repr__(self) -> str:
         return f"AsyncPolyforgeClient(api_key='[REDACTED]', base_url='{self._api_url}')"
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_client", None)
+        return state
 
     # -- helpers --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -451,6 +451,46 @@ class TestReprSecurity:
         assert "[REDACTED]" in repr_str
 
 
+class TestApiKeyNotInInstanceDict:
+    """CWE-522: API key must not be accessible via vars() or __dict__."""
+
+    def test_sync_client_vars_does_not_contain_api_key(self):
+        client = PolyforgeClient(api_key="pf_live_supersecretkey123456")
+        instance_vars = vars(client)
+        for value in instance_vars.values():
+            if isinstance(value, str):
+                assert "supersecretkey123456" not in value
+        assert "_api_key" not in instance_vars
+        client.close()
+
+    def test_async_client_vars_does_not_contain_api_key(self):
+        client = AsyncPolyforgeClient(api_key="pf_live_supersecretkey123456")
+        instance_vars = vars(client)
+        for value in instance_vars.values():
+            if isinstance(value, str):
+                assert "supersecretkey123456" not in value
+        assert "_api_key" not in instance_vars
+
+
+class TestGetstateSafety:
+    """API key must not leak through __getstate__ serialization."""
+
+    def test_sync_client_getstate_excludes_client(self):
+        client = PolyforgeClient(api_key="pf_live_supersecretkey123456")
+        state = client.__getstate__()
+        assert "_client" not in state
+        serialized = str(state)
+        assert "supersecretkey123456" not in serialized
+        client.close()
+
+    def test_async_client_getstate_excludes_client(self):
+        client = AsyncPolyforgeClient(api_key="pf_live_supersecretkey123456")
+        state = client.__getstate__()
+        assert "_client" not in state
+        serialized = str(state)
+        assert "supersecretkey123456" not in serialized
+
+
 class TestWebhookValidation:
     """Test webhook URL SSRF validation."""
 


### PR DESCRIPTION
## Summary

- Remove redundant `self._api_key` from `PolyforgeClient` and `AsyncPolyforgeClient` — the key was already embedded in httpx client headers and never read back after `__init__`
- Add `__getstate__` to both client classes to exclude the httpx `_client` object (which holds the `Authorization` header) from pickle serialization
- Add 4 security tests: `vars()` key absence + `__getstate__` safety for both sync and async clients

Fixes CWE-522 (Insufficiently Protected Credentials). Closes #127.

## Test plan

- [x] All 366 tests pass (4 new + 362 existing)
- [x] `vars(client)` no longer contains `_api_key`
- [x] `__getstate__()` returns state without `_client` or key material
- [x] `__repr__` still redacts correctly (existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)