### PR TITLE
fix(compat): marketplace listing sends priceUsdc and title (POLA-335)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1238,6 +1238,7 @@ class PolyforgeClient:
     def create_marketplace_listing(
         self,
         strategy_id: str,
+        title: str,
         price: float,
         *,
         description: str | None = None,
@@ -1246,6 +1247,7 @@ class PolyforgeClient:
 
         Args:
             strategy_id: The ID of the strategy to list.
+            title: Listing title (required by the API).
             price: Listing price in USDC (must be positive).
             description: Optional description for the listing.
 
@@ -1253,7 +1255,7 @@ class PolyforgeClient:
             The created :class:`MarketplaceListing`.
         """
         _validate_financial_param("price", price)
-        body: dict[str, Any] = {"strategyId": strategy_id, "price": price}
+        body: dict[str, Any] = {"strategyId": strategy_id, "title": title, "priceUsdc": price}
         if description is not None:
             body["description"] = description
         return _parse(MarketplaceListing, self._post("/api/v1/marketplace", json=body))
@@ -2762,13 +2764,14 @@ class AsyncPolyforgeClient:
     async def create_marketplace_listing(
         self,
         strategy_id: str,
+        title: str,
         price: float,
         *,
         description: str | None = None,
     ) -> MarketplaceListing:
         """Create a new marketplace listing for one of your strategies."""
         _validate_financial_param("price", price)
-        body: dict[str, Any] = {"strategyId": strategy_id, "price": price}
+        body: dict[str, Any] = {"strategyId": strategy_id, "title": title, "priceUsdc": price}
         if description is not None:
             body["description"] = description
         return _parse(MarketplaceListing, await self._post("/api/v1/marketplace", json=body))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2549,6 +2549,7 @@ class TestMarketplaceSellerCrud:
         sig = inspect.signature(PolyforgeClient.create_marketplace_listing)
         params = set(sig.parameters.keys())
         assert "strategy_id" in params
+        assert "title" in params
         assert "price" in params
         assert "description" in params
 
@@ -2563,10 +2564,30 @@ class TestMarketplaceSellerCrud:
         assert "/api/v1/marketplace" in source
         assert "_post" in source
 
+    def test_sync_create_marketplace_listing_sends_priceUsdc(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.create_marketplace_listing)
+        assert '"priceUsdc"' in source, "must send priceUsdc, not price"
+
+    def test_sync_create_marketplace_listing_sends_title(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.create_marketplace_listing)
+        assert '"title"' in source, "must include title in request body"
+
     def test_async_create_marketplace_listing_path(self):
         import inspect
         source = inspect.getsource(AsyncPolyforgeClient.create_marketplace_listing)
         assert "/api/v1/marketplace" in source
+
+    def test_async_create_marketplace_listing_sends_priceUsdc(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.create_marketplace_listing)
+        assert '"priceUsdc"' in source, "must send priceUsdc, not price"
+
+    def test_async_create_marketplace_listing_sends_title(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.create_marketplace_listing)
+        assert '"title"' in source, "must include title in request body"
 
     # -- update_marketplace_listing --
 


### PR DESCRIPTION
## Summary
- **Fixed `price` → `priceUsdc`**: Both sync and async `create_marketplace_listing` were sending `"price"` as the JSON key instead of the API-expected `"priceUsdc"`, causing 400 errors.
- **Added required `title` parameter**: The `title` field was missing from the method signature entirely, despite being required by the API schema.
- **Added 4 new regression tests**: Source-level assertions verify `"priceUsdc"` and `"title"` appear in both sync and async method bodies.

## Test plan
- [x] All 366 tests pass in clean worktree
- [x] New tests assert `"priceUsdc"` key in sync body construction
- [x] New tests assert `"priceUsdc"` key in async body construction
- [x] New tests assert `"title"` key in both sync and async body construction
- [x] Param test updated to check for `title` in method signature

Closes polyforge-sdk-python#159

🤖 Generated with [Claude Code](https://claude.com/claude-code)