### PR TITLE
fix(compat): expand update_strategy() params (POLA-348)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -682,7 +682,27 @@ class PolyforgeClient:
     def export_strategy(self, strategy_id: str) -> dict:
         return self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/export")
 
-    def update_strategy(self, strategy_id: str, name: str | None = None, description: str | None = None, market_id: str | None = None) -> Strategy:
+    def update_strategy(
+        self,
+        strategy_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        market_id: str | None = None,
+        visibility: str | None = None,
+        exec_mode: str | None = None,
+        tick_ms: int | None = None,
+        triggers: list[dict[str, Any]] | None = None,
+        conditions: list[dict[str, Any]] | None = None,
+        actions: list[dict[str, Any]] | None = None,
+        safety: list[dict[str, Any]] | None = None,
+        logic_blocks: list[dict[str, Any]] | None = None,
+        calc_blocks: list[dict[str, Any]] | None = None,
+        tags: list[str] | None = None,
+        variables: list[dict[str, Any]] | None = None,
+        canvas: dict[str, Any] | None = None,
+        market_slots: list[dict[str, Any]] | None = None,
+    ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
             body["name"] = name
@@ -690,6 +710,32 @@ class PolyforgeClient:
             body["description"] = description
         if market_id is not None:
             body["marketId"] = market_id
+        if visibility is not None:
+            body["visibility"] = visibility
+        if exec_mode is not None:
+            body["execMode"] = exec_mode
+        if tick_ms is not None:
+            body["tickMs"] = tick_ms
+        if triggers is not None:
+            body["triggers"] = triggers
+        if conditions is not None:
+            body["conditions"] = conditions
+        if actions is not None:
+            body["actions"] = actions
+        if safety is not None:
+            body["safety"] = safety
+        if logic_blocks is not None:
+            body["logicBlocks"] = logic_blocks
+        if calc_blocks is not None:
+            body["calcBlocks"] = calc_blocks
+        if tags is not None:
+            body["tags"] = tags
+        if variables is not None:
+            body["variables"] = variables
+        if canvas is not None:
+            body["canvas"] = canvas
+        if market_slots is not None:
+            body["marketSlots"] = market_slots
         return _parse(Strategy, self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
     def delete_strategy(self, strategy_id: str) -> None:
@@ -2230,7 +2276,27 @@ class AsyncPolyforgeClient:
     async def export_strategy(self, strategy_id: str) -> dict:
         return await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/export")
 
-    async def update_strategy(self, strategy_id: str, name: str | None = None, description: str | None = None, market_id: str | None = None) -> Strategy:
+    async def update_strategy(
+        self,
+        strategy_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        market_id: str | None = None,
+        visibility: str | None = None,
+        exec_mode: str | None = None,
+        tick_ms: int | None = None,
+        triggers: list[dict[str, Any]] | None = None,
+        conditions: list[dict[str, Any]] | None = None,
+        actions: list[dict[str, Any]] | None = None,
+        safety: list[dict[str, Any]] | None = None,
+        logic_blocks: list[dict[str, Any]] | None = None,
+        calc_blocks: list[dict[str, Any]] | None = None,
+        tags: list[str] | None = None,
+        variables: list[dict[str, Any]] | None = None,
+        canvas: dict[str, Any] | None = None,
+        market_slots: list[dict[str, Any]] | None = None,
+    ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
             body["name"] = name
@@ -2238,6 +2304,32 @@ class AsyncPolyforgeClient:
             body["description"] = description
         if market_id is not None:
             body["marketId"] = market_id
+        if visibility is not None:
+            body["visibility"] = visibility
+        if exec_mode is not None:
+            body["execMode"] = exec_mode
+        if tick_ms is not None:
+            body["tickMs"] = tick_ms
+        if triggers is not None:
+            body["triggers"] = triggers
+        if conditions is not None:
+            body["conditions"] = conditions
+        if actions is not None:
+            body["actions"] = actions
+        if safety is not None:
+            body["safety"] = safety
+        if logic_blocks is not None:
+            body["logicBlocks"] = logic_blocks
+        if calc_blocks is not None:
+            body["calcBlocks"] = calc_blocks
+        if tags is not None:
+            body["tags"] = tags
+        if variables is not None:
+            body["variables"] = variables
+        if canvas is not None:
+            body["canvas"] = canvas
+        if market_slots is not None:
+            body["marketSlots"] = market_slots
         return _parse(Strategy, await self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
     async def delete_strategy(self, strategy_id: str) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -965,6 +965,60 @@ class TestCreateStrategyParams:
         assert '"tags"' in source
 
 
+class TestUpdateStrategyParams:
+    """Tests for update_strategy() accepting all platform-supported fields (#144)."""
+
+    def test_update_strategy_accepts_all_params(self):
+        """update_strategy() must accept visibility, exec_mode, blocks, tags, etc."""
+        import inspect
+        sig = inspect.signature(PolyforgeClient.update_strategy)
+        params = set(sig.parameters.keys())
+        for expected in (
+            "name", "description", "market_id", "visibility", "exec_mode",
+            "tick_ms", "triggers", "conditions", "actions", "safety",
+            "logic_blocks", "calc_blocks", "tags", "variables", "canvas",
+            "market_slots",
+        ):
+            assert expected in params, f"missing param: {expected}"
+
+    def test_async_update_strategy_accepts_all_params(self):
+        """Async update_strategy() must also accept the expanded params."""
+        import inspect
+        sig = inspect.signature(AsyncPolyforgeClient.update_strategy)
+        params = set(sig.parameters.keys())
+        for expected in (
+            "name", "description", "market_id", "visibility", "exec_mode",
+            "tick_ms", "triggers", "conditions", "actions", "safety",
+            "logic_blocks", "calc_blocks", "tags", "variables", "canvas",
+            "market_slots",
+        ):
+            assert expected in params, f"missing async param: {expected}"
+
+    def test_update_strategy_sends_camel_case_fields(self):
+        """update_strategy() must send camelCase field names to the API."""
+        import inspect
+        source = inspect.getsource(PolyforgeClient.update_strategy)
+        for camel in (
+            '"visibility"', '"execMode"', '"tickMs"', '"triggers"',
+            '"conditions"', '"actions"', '"safety"', '"logicBlocks"',
+            '"calcBlocks"', '"tags"', '"variables"', '"canvas"',
+            '"marketSlots"',
+        ):
+            assert camel in source, f"missing camelCase key: {camel}"
+
+    def test_update_strategy_params_are_keyword_only(self):
+        """All update params after strategy_id must be keyword-only."""
+        import inspect
+        sig = inspect.signature(PolyforgeClient.update_strategy)
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            if pname == "strategy_id":
+                assert param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            else:
+                assert param.kind == inspect.Parameter.KEYWORD_ONLY, f"{pname} should be keyword-only"
+
+
 class TestPaginatedResponseDataField:
     """Tests for PaginatedResponse using 'data' field (#33)."""
 


### PR DESCRIPTION
## Summary

- Expanded `update_strategy()` (sync + async) to accept all 16 platform-supported fields, matching the TypeScript SDK's `UpdateStrategyParams` interface
- Added 13 missing parameters: `visibility`, `exec_mode`, `tick_ms`, `triggers`, `conditions`, `actions`, `safety`, `logic_blocks`, `calc_blocks`, `tags`, `variables`, `canvas`, `market_slots`
- All parameters are keyword-only after `strategy_id` for safety
- Added 4 new tests verifying parameter presence, camelCase serialization, and keyword-only enforcement

## Test plan

- [x] All 4 new tests in `TestUpdateStrategyParams` pass
- [x] Full test suite (366 tests) passes with zero regressions
- [ ] CI pipeline validates lint, typecheck, and test gates

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)