### PR TITLE
fix(compat): serialize alert price as string for @IsNumberString (#162)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1505,7 +1505,7 @@ class PolyforgeClient:
         body: dict[str, Any] = {
             "tokenId": token_id,
             "direction": direction,
-            "price": price,
+            "price": str(price),
             "persistent": persistent,
         }
         return _parse(Alert, self._post("/api/v1/alerts", json=body))
@@ -2938,7 +2938,7 @@ class AsyncPolyforgeClient:
         body: dict[str, Any] = {
             "tokenId": token_id,
             "direction": direction,
-            "price": price,
+            "price": str(price),
             "persistent": persistent,
         }
         return _parse(Alert, await self._post("/api/v1/alerts", json=body))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1866,6 +1866,26 @@ class TestAlertCrud:
         assert "/api/v1/alerts/" in source
         assert "_delete" in source
 
+    # -- Regression: price must be sent as string (#162 / POLA-332) --
+
+    def test_sync_create_alert_sends_price_as_string(self):
+        """create_alert() must convert price to str for @IsNumberString."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.create_alert)
+        assert 'str(price)' in source, (
+            "price must be serialised as str(price) — platform requires @IsNumberString"
+        )
+
+    def test_async_create_alert_sends_price_as_string(self):
+        """Async create_alert() must convert price to str for @IsNumberString."""
+        import inspect
+
+        source = inspect.getsource(AsyncPolyforgeClient.create_alert)
+        assert 'str(price)' in source, (
+            "price must be serialised as str(price) — platform requires @IsNumberString"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Conditional Orders (#50)


### PR DESCRIPTION
## Summary
- Convert `price` from `float` to `str()` in both sync and async `create_alert()` before sending the JSON body
- The platform's `CreateAlertDto` validates `price` with `@IsNumberString()`, which rejects raw floats — this was a regression of #122
- Adds 2 regression tests that inspect source for `str(price)` conversion

## Context
POLA-332 / polyforge-sdk-python#162. The SDK accepted `price: float` for ergonomics but sent the raw float in the JSON payload. NestJS `class-validator`'s `@IsNumberString()` rejects non-string values, causing 400 errors on the platform.

**Note:** The same float-vs-string pattern affects other endpoints (`create_conditional_order.limitPrice`, `create_copy_config.priceOffset/sizeValue/maxExposure/maxDailyLoss`). Those should be addressed in a follow-up issue.

## Test plan
- [x] 2 new regression tests verify `str(price)` in source
- [x] Full suite: 364 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)