### PR TITLE
fix(compat): align PriceHistoryEntry with platform OHLCV candles

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -74,6 +74,10 @@ from polyforge.models import (
 
 T = TypeVar("T")
 
+_FIELD_ALIASES: dict[str, dict[str, str]] = {
+    "PriceHistoryEntry": {"time": "timestamp"},
+}
+
 _MODEL_REGISTRY: dict[str, type] = {
     "Market": Market,
     "Token": Token,
@@ -139,14 +143,17 @@ def _parse(cls: type[T], data: dict[str, Any]) -> T:
     if not isinstance(data, dict):
         return data  # type: ignore[return-value]
 
+    aliases = _FIELD_ALIASES.get(cls.__name__, {})
+    aliased = {aliases.get(k, k): v for k, v in data.items()}
+
     # Build a snake_case lookup so camelCase API keys map to dataclass fields
-    snake_data = {_camel_to_snake(k): v for k, v in data.items()}
+    snake_data = {_camel_to_snake(k): v for k, v in aliased.items()}
 
     hints = get_type_hints(cls)
     kwargs: dict[str, Any] = {}
 
     for f in fields(cls):  # type: ignore[arg-type]
-        raw = data.get(f.name) or snake_data.get(f.name)
+        raw = aliased.get(f.name) or snake_data.get(f.name)
         if raw is None:
             continue
 
@@ -164,6 +171,8 @@ def _parse(cls: type[T], data: dict[str, Any]) -> T:
                 kwargs[f.name] = [_parse(_MODEL_REGISTRY[inner_name], item) for item in raw]
             else:
                 kwargs[f.name] = raw
+        elif hint is float and isinstance(raw, str):
+            kwargs[f.name] = float(raw)
         else:
             kwargs[f.name] = raw
 

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -591,11 +591,18 @@ class MarketSentiment:
 
 @dataclass
 class PriceHistoryEntry:
-    """A single data point in a market's price history."""
+    """A single OHLCV candle in a market's price history."""
 
     timestamp: str = ""
-    price: float = 0.0
+    open: float = 0.0
+    high: float = 0.0
+    low: float = 0.0
+    close: float = 0.0
     volume: float = 0.0
+
+    @property
+    def price(self) -> float:
+        return self.close
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1615,21 +1615,36 @@ class TestWebhookMutationMethods:
 
 
 class TestPriceHistoryEntryModel:
-    """Tests for PriceHistoryEntry model (#51)."""
+    """Tests for PriceHistoryEntry model (#51, #148)."""
 
-    def test_price_history_entry_fields(self):
-        """PriceHistoryEntry must have timestamp, price, volume fields."""
-        entry = PriceHistoryEntry(timestamp="2026-04-13T00:00:00Z", price=0.65, volume=1234.5)
+    def test_price_history_entry_ohlcv_fields(self):
+        """PriceHistoryEntry must have timestamp and OHLCV fields."""
+        entry = PriceHistoryEntry(
+            timestamp="2026-04-13T00:00:00Z",
+            open=0.45, high=0.70, low=0.40, close=0.65, volume=1234.5,
+        )
         assert entry.timestamp == "2026-04-13T00:00:00Z"
-        assert entry.price == 0.65
+        assert entry.open == 0.45
+        assert entry.high == 0.70
+        assert entry.low == 0.40
+        assert entry.close == 0.65
         assert entry.volume == 1234.5
+
+    def test_price_history_entry_price_compat(self):
+        """PriceHistoryEntry.price should alias close for backward compatibility (#148)."""
+        entry = PriceHistoryEntry(close=0.65)
+        assert entry.price == 0.65
 
     def test_price_history_entry_defaults(self):
         """PriceHistoryEntry defaults should be sensible."""
         entry = PriceHistoryEntry()
         assert entry.timestamp == ""
-        assert entry.price == 0.0
+        assert entry.open == 0.0
+        assert entry.high == 0.0
+        assert entry.low == 0.0
+        assert entry.close == 0.0
         assert entry.volume == 0.0
+        assert entry.price == 0.0
 
 
 class TestOrderBookModels:
@@ -1722,6 +1737,44 @@ class TestGetPriceHistory:
         sig = inspect.signature(PolyforgeClient.get_price_history)
         ret = sig.return_annotation
         assert "PriceHistoryEntry" in str(ret)
+
+    def test_parse_ohlcv_candle_from_platform_response(self):
+        """_parse must map platform OHLCV candle shape to PriceHistoryEntry (#148)."""
+        from polyforge.client import _parse
+
+        candle = {
+            "time": "2026-04-13T12:00:00Z",
+            "open": "0.450000",
+            "high": "0.700000",
+            "low": "0.400000",
+            "close": "0.650000",
+            "volume": "1234.560000",
+        }
+        entry = _parse(PriceHistoryEntry, candle)
+        assert entry.timestamp == "2026-04-13T12:00:00Z"
+        assert entry.open == 0.45
+        assert entry.high == 0.70
+        assert entry.low == 0.40
+        assert entry.close == 0.65
+        assert entry.volume == 1234.56
+        assert entry.price == 0.65
+
+    def test_parse_ohlcv_candle_zero_defaults(self):
+        """_parse handles '0' string values from platform correctly (#148)."""
+        from polyforge.client import _parse
+
+        candle = {
+            "time": "2026-04-13T12:00:00Z",
+            "open": "0",
+            "high": "0",
+            "low": "0",
+            "close": "0",
+            "volume": "0",
+        }
+        entry = _parse(PriceHistoryEntry, candle)
+        assert entry.timestamp == "2026-04-13T12:00:00Z"
+        assert entry.open == 0.0
+        assert entry.close == 0.0
 
 
 class TestGetOrderBook:


### PR DESCRIPTION
## Summary

Closes #148 (POLA-344)

- **Updated `PriceHistoryEntry` model** with full OHLCV fields: `open`, `high`, `low`, `close`, `volume`
- **Added `price` backward-compat property** aliasing `close` so existing consumers don't break
- **Added `_FIELD_ALIASES` mechanism** in `_parse()` to map platform's `time` → SDK's `timestamp`
- **Added string→float coercion** in `_parse()` for numeric fields (platform sends Decimal strings)
- **Added 4 new tests**, updated 2 existing tests (net +3 tests, total 369)

## What changed

| File | Change |
|------|--------|
| `src/polyforge/models.py` | `PriceHistoryEntry` now has OHLCV fields + `price` property |
| `src/polyforge/client.py` | `_FIELD_ALIASES` dict + alias/coercion logic in `_parse()` |
| `tests/test_client.py` | Updated model tests, added OHLCV parsing integration tests |

## Test plan

- [x] All 367 tests pass (2 pre-existing POLA-354 failures excluded)
- [x] New OHLCV field tests pass
- [x] Backward compat `entry.price == entry.close` verified
- [x] String→float coercion tested with platform response shape
- [x] Zero-value edge case tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)