### PR TITLE
fix(sdk): send paperMode/deploymentMode instead of mode in start_strategy (#150)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -225,6 +225,7 @@ def _validate_enum(name: str, value: str, allowed: frozenset[str]) -> None:
 
 
 _VALID_MODES = frozenset({"live", "paper"})
+_VALID_DEPLOYMENT_MODES = frozenset({"LIVE", "SIMULATION"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
 _VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "FAK"})
@@ -671,9 +672,13 @@ class PolyforgeClient:
             body["marketId"] = market_id
         return _parse(Strategy, self._post("/api/v1/strategies/from-description", json=body))
 
-    def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
-        _validate_enum("mode", mode, _VALID_MODES)
-        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
+    def start_strategy(self, strategy_id: str, paper_mode: bool = True,
+                       deployment_mode: str | None = None) -> StrategyStatusResponse:
+        body: dict[str, Any] = {"paperMode": paper_mode}
+        if deployment_mode is not None:
+            _validate_enum("deploymentMode", deployment_mode, _VALID_DEPLOYMENT_MODES)
+            body["deploymentMode"] = deployment_mode
+        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json=body))
 
     def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))
@@ -2271,9 +2276,13 @@ class AsyncPolyforgeClient:
             body["marketId"] = market_id
         return _parse(Strategy, await self._post("/api/v1/strategies/from-description", json=body))
 
-    async def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
-        _validate_enum("mode", mode, _VALID_MODES)
-        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
+    async def start_strategy(self, strategy_id: str, paper_mode: bool = True,
+                             deployment_mode: str | None = None) -> StrategyStatusResponse:
+        body: dict[str, Any] = {"paperMode": paper_mode}
+        if deployment_mode is not None:
+            _validate_enum("deploymentMode", deployment_mode, _VALID_DEPLOYMENT_MODES)
+            body["deploymentMode"] = deployment_mode
+        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json=body))
 
     async def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -660,12 +660,13 @@ class TestPlatformContractCompliance:
         source = inspect.getsource(PolyforgeClient.create_strategy_from_description)
         assert '"description"' in source or "'description'" in source
 
-    def test_start_strategy_sends_lowercase_mode(self):
-        """start_strategy() must not call .upper() on mode (#92)."""
+    def test_start_strategy_sends_paper_mode_field(self):
+        """start_strategy() must send paperMode boolean, not {mode} string (#150)."""
         import inspect
 
         source = inspect.getsource(PolyforgeClient.start_strategy)
-        assert ".upper()" not in source, "start_strategy() must not uppercase the mode value"
+        assert "paperMode" in source, "start_strategy() must send 'paperMode' field to match platform contract"
+        assert '"mode"' not in source and "'mode'" not in source, "start_strategy() must not send legacy 'mode' field"
 
 
 class TestFinancialParamValidation:
@@ -717,10 +718,10 @@ class TestEnumValidation:
         with pytest.raises(ValueError, match="must be one of"):
             _validate_enum("side", "HOLD", frozenset({"BUY", "SELL"}))
 
-    def test_start_strategy_rejects_invalid_mode(self):
+    def test_start_strategy_rejects_invalid_deployment_mode(self):
         client = PolyforgeClient(api_key="test-key")
         with pytest.raises(ValueError, match="must be one of"):
-            client.start_strategy("s-1", mode="turbo")
+            client.start_strategy("s-1", deployment_mode="turbo")
 
     def test_place_order_rejects_invalid_side(self):
         client = PolyforgeClient(api_key="test-key")


### PR DESCRIPTION
## Summary

- **Critical safety fix**: `start_strategy()` was sending `{"mode": "paper"}` but the platform expects `{"paperMode": true, "deploymentMode": "SIMULATION"}`. The platform silently ignores unknown fields so `paperMode` defaulted to `false`, causing all strategies to run in live mode regardless of user intent.
- Signature changed: `paper_mode: bool = True, deployment_mode: str | None = None`
- Added `_VALID_DEPLOYMENT_MODES = frozenset({"LIVE", "SIMULATION"})` for `deployment_mode` validation
- Both `PolyforgeClient` (sync) and `AsyncPolyforgeClient` (async) updated
- Updated tests: `test_start_strategy_sends_paper_mode_field` verifies `paperMode` field; `test_start_strategy_rejects_invalid_deployment_mode` verifies enum validation

## Breaking change

Callers using `start_strategy("id", mode="paper")` must update to `start_strategy("id", paper_mode=True)`. The default `paper_mode=True` is safe — omitting the argument now correctly sends paper mode.

## Test plan

- [x] All 382 existing tests pass (`pytest tests/test_client.py`)
- [x] `test_start_strategy_sends_paper_mode_field` confirms `paperMode` in source, no legacy `mode` field
- [x] `test_start_strategy_rejects_invalid_deployment_mode` confirms validation of `deployment_mode` enum

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)