### PR TITLE
fix: batch_requests sends 'items' to match platform DTO

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1447,7 +1447,7 @@ class PolyforgeClient:
         Returns:
             A list of :class:`BatchResult` objects, one per request.
         """
-        data = self._post("/api/v1/batch", json={"requests": requests})
+        data = self._post("/api/v1/batch", json={"items": requests})
         items = data if isinstance(data, list) else data.get("results", [])
         return [_parse(BatchResult, r) for r in items]
 
@@ -2965,7 +2965,7 @@ class AsyncPolyforgeClient:
 
     async def batch_requests(self, requests: list[dict[str, Any]]) -> list[BatchResult]:
         """Execute multiple API requests in a single round-trip."""
-        data = await self._post("/api/v1/batch", json={"requests": requests})
+        data = await self._post("/api/v1/batch", json={"items": requests})
         items = data if isinstance(data, list) else data.get("results", [])
         return [_parse(BatchResult, r) for r in items]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2464,6 +2464,47 @@ class TestBatchApi:
         source = inspect.getsource(AsyncPolyforgeClient.batch_requests)
         assert "/api/v1/batch" in source
 
+    def test_sync_batch_requests_sends_items_key(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.batch_requests)
+        assert '"items"' in source
+        assert '"requests"' not in source or "requests)" in source
+
+    def test_async_batch_requests_sends_items_key(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.batch_requests)
+        assert '"items"' in source
+        assert '"requests"' not in source or "requests)" in source
+
+    def test_sync_batch_requests_payload(self):
+        from unittest.mock import MagicMock
+        client = PolyforgeClient(api_key="test-key")
+        fake_response = [{"id": "1", "status": 200, "body": {}}]
+        client._post = MagicMock(return_value=fake_response)
+        reqs = [{"id": "1", "method": "GET", "path": "/api/v1/markets"}]
+        client.batch_requests(reqs)
+        client._post.assert_called_once_with(
+            "/api/v1/batch", json={"items": reqs},
+        )
+        client.close()
+
+    def test_async_batch_requests_payload(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            fake_response = [{"id": "1", "status": 200, "body": {}}]
+            client._post = AsyncMock(return_value=fake_response)
+            reqs = [{"id": "1", "method": "GET", "path": "/api/v1/markets"}]
+            await client.batch_requests(reqs)
+            client._post.assert_called_once_with(
+                "/api/v1/batch", json={"items": reqs},
+            )
+            await client.close()
+
+        asyncio.run(_run())
+
 
 class TestExtendedWhaleIntelligence:
     """Tests for get_top_whales, get_whale_profile, follow/unfollow, get_followed_whales."""


### PR DESCRIPTION
## Summary

- Fix `batch_requests()` payload key from `"requests"` to `"items"` in both sync and async clients
- The platform's `BatchRequestDto` validates for `items` — this was causing HTTP 400 on every batch call
- Aligns Python SDK with TypeScript and Rust SDKs which already use the correct key

Closes #155
Resolves [POLA-339](http://polyforge-lab:3100/POLA/issues/POLA-339)

## Changes

| File | Change |
|------|--------|
| `src/polyforge/client.py:1450` | `json={"requests": ...}` → `json={"items": ...}` (sync) |
| `src/polyforge/client.py:2968` | `json={"requests": ...}` → `json={"items": ...}` (async) |
| `tests/test_client.py` | +4 tests: source inspection + mock-based payload verification for both clients |

## Test plan

- [x] All 386 tests pass (4 new, 0 removed)
- [ ] Verify batch endpoint works against staging with Python SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)