### PR TITLE
feat(compat): add missing query params to get_news_signals and get_whale_feed

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1453,8 +1453,22 @@ class PolyforgeClient:
 
     # -- Social & Signals --
 
-    def get_whale_feed(self, *, min_size: int = 10000) -> list[WhaleTrade]:
-        data = self._get("/api/v1/whales/feed", params={"minSize": min_size})
+    def get_whale_feed(
+        self,
+        *,
+        min_size: int = 10000,
+        market_id: str | None = None,
+        wallet_address: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> list[WhaleTrade]:
+        data = self._get("/api/v1/whales/feed", params=_strip_none({
+            "minSize": min_size,
+            "marketId": market_id,
+            "walletAddress": wallet_address,
+            "page": page,
+            "limit": limit,
+        }))
         items = data["data"]
         return [_parse(WhaleTrade, w) for w in items]
 
@@ -1523,8 +1537,22 @@ class PolyforgeClient:
         items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(WhaleProfile, w) for w in items]
 
-    def get_news_signals(self, *, min_confidence: int = 70) -> list[NewsSignal]:
-        data = self._get("/api/v1/news/signals", params={"minConfidence": min_confidence})
+    def get_news_signals(
+        self,
+        *,
+        min_confidence: int = 70,
+        market_id: str | None = None,
+        direction: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> list[NewsSignal]:
+        data = self._get("/api/v1/news/signals", params=_strip_none({
+            "minConfidence": min_confidence,
+            "marketId": market_id,
+            "direction": direction,
+            "page": page,
+            "limit": limit,
+        }))
         items = data["data"]
         return [_parse(NewsSignal, s) for s in items]
 
@@ -2971,8 +2999,22 @@ class AsyncPolyforgeClient:
 
     # -- Social & Signals --
 
-    async def get_whale_feed(self, *, min_size: int = 10000) -> list[WhaleTrade]:
-        data = await self._get("/api/v1/whales/feed", params={"minSize": min_size})
+    async def get_whale_feed(
+        self,
+        *,
+        min_size: int = 10000,
+        market_id: str | None = None,
+        wallet_address: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> list[WhaleTrade]:
+        data = await self._get("/api/v1/whales/feed", params=_strip_none({
+            "minSize": min_size,
+            "marketId": market_id,
+            "walletAddress": wallet_address,
+            "page": page,
+            "limit": limit,
+        }))
         items = data["data"]
         return [_parse(WhaleTrade, w) for w in items]
 
@@ -3008,8 +3050,22 @@ class AsyncPolyforgeClient:
         items = data if isinstance(data, list) else data.get("data", [])
         return [_parse(WhaleProfile, w) for w in items]
 
-    async def get_news_signals(self, *, min_confidence: int = 70) -> list[NewsSignal]:
-        data = await self._get("/api/v1/news/signals", params={"minConfidence": min_confidence})
+    async def get_news_signals(
+        self,
+        *,
+        min_confidence: int = 70,
+        market_id: str | None = None,
+        direction: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> list[NewsSignal]:
+        data = await self._get("/api/v1/news/signals", params=_strip_none({
+            "minConfidence": min_confidence,
+            "marketId": market_id,
+            "direction": direction,
+            "page": page,
+            "limit": limit,
+        }))
         items = data["data"]
         return [_parse(NewsSignal, s) for s in items]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3056,3 +3056,133 @@ class TestRiskSettings:
     def test_risk_settings_exported_from_package(self):
         from polyforge import RiskSettings
         assert RiskSettings is not None
+
+
+class TestNewsSignalsWhalesFeedParams:
+    """Tests for get_news_signals and get_whale_feed missing query params (#132)."""
+
+    # -- get_whale_feed --
+
+    def test_sync_get_whale_feed_exists(self):
+        assert hasattr(PolyforgeClient, "get_whale_feed")
+
+    def test_async_get_whale_feed_exists(self):
+        assert hasattr(AsyncPolyforgeClient, "get_whale_feed")
+
+    def test_sync_get_whale_feed_has_all_params(self):
+        import inspect
+        sig = inspect.signature(PolyforgeClient.get_whale_feed)
+        params = set(sig.parameters.keys())
+        assert "min_size" in params
+        assert "market_id" in params
+        assert "wallet_address" in params
+        assert "page" in params
+        assert "limit" in params
+
+    def test_async_get_whale_feed_has_all_params(self):
+        import inspect
+        sig = inspect.signature(AsyncPolyforgeClient.get_whale_feed)
+        params = set(sig.parameters.keys())
+        assert "min_size" in params
+        assert "market_id" in params
+        assert "wallet_address" in params
+        assert "page" in params
+        assert "limit" in params
+
+    def test_sync_get_whale_feed_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_whale_feed)
+        assert "/api/v1/whales/feed" in source
+        assert "_get" in source
+
+    def test_async_get_whale_feed_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_whale_feed)
+        assert "/api/v1/whales/feed" in source
+
+    def test_sync_get_whale_feed_maps_camel_case_params(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_whale_feed)
+        assert "marketId" in source
+        assert "walletAddress" in source
+        assert "minSize" in source
+
+    def test_async_get_whale_feed_maps_camel_case_params(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_whale_feed)
+        assert "marketId" in source
+        assert "walletAddress" in source
+        assert "minSize" in source
+
+    def test_sync_get_whale_feed_uses_strip_none(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_whale_feed)
+        assert "_strip_none" in source
+
+    def test_async_get_whale_feed_uses_strip_none(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_whale_feed)
+        assert "_strip_none" in source
+
+    # -- get_news_signals --
+
+    def test_sync_get_news_signals_exists(self):
+        assert hasattr(PolyforgeClient, "get_news_signals")
+
+    def test_async_get_news_signals_exists(self):
+        assert hasattr(AsyncPolyforgeClient, "get_news_signals")
+
+    def test_sync_get_news_signals_has_all_params(self):
+        import inspect
+        sig = inspect.signature(PolyforgeClient.get_news_signals)
+        params = set(sig.parameters.keys())
+        assert "min_confidence" in params
+        assert "market_id" in params
+        assert "direction" in params
+        assert "page" in params
+        assert "limit" in params
+
+    def test_async_get_news_signals_has_all_params(self):
+        import inspect
+        sig = inspect.signature(AsyncPolyforgeClient.get_news_signals)
+        params = set(sig.parameters.keys())
+        assert "min_confidence" in params
+        assert "market_id" in params
+        assert "direction" in params
+        assert "page" in params
+        assert "limit" in params
+
+    def test_sync_get_news_signals_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_news_signals)
+        assert "/api/v1/news/signals" in source
+        assert "_get" in source
+
+    def test_async_get_news_signals_uses_correct_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_news_signals)
+        assert "/api/v1/news/signals" in source
+
+    def test_sync_get_news_signals_maps_camel_case_params(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_news_signals)
+        assert "minConfidence" in source
+        assert "marketId" in source
+        assert "direction" in source
+
+    def test_async_get_news_signals_maps_camel_case_params(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_news_signals)
+        assert "minConfidence" in source
+        assert "marketId" in source
+        assert "direction" in source
+
+    def test_sync_get_news_signals_uses_strip_none(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_news_signals)
+        assert "_strip_none" in source
+
+    def test_async_get_news_signals_uses_strip_none(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_news_signals)
+        assert "_strip_none" in source


### PR DESCRIPTION
## Summary

Closes #132 — feature parity gap between the platform DTOs and the Python SDK for two endpoints.

- **`get_whale_feed`**: adds `market_id`, `wallet_address`, `page`, `limit` (mapped to `marketId`, `walletAddress`, `page`, `limit`). Converts from a fixed `params` dict to `_strip_none` so `None` values are never sent.
- **`get_news_signals`**: adds `market_id`, `direction`, `page`, `limit` (mapped to `marketId`, `direction`, `page`, `limit`). Same `_strip_none` pattern.
- Both changes applied to `PolyforgeClient` (sync) and `AsyncPolyforgeClient` (async).
- 20 new tests added covering param presence, camelCase mapping, correct endpoint path, and `_strip_none` usage.

## Test plan

- [ ] `PYTHONPATH=src python3 -m pytest tests/test_client.py -q` → 402 passed
- [ ] New class `TestNewsSignalsWhalesFeedParams` → 20/20 passed
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.ai/claude-code)