### PR TITLE
test(compat): add path regression tests for 12 endpoints (closes #149)

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4232,3 +4232,89 @@ class TestOrderPlatformContract:
         assert order.outcome == "YES"
         assert order.intent_id == "int-1"
         assert order.strategy_id == "str-1"
+
+
+class TestEndpointPathRegression:
+    """Regression tests for issue #149: 12 SDK paths that previously returned 404.
+
+    Each test asserts the exact platform-correct path is present in the method
+    source so a future edit cannot silently revert to the broken path.
+    """
+
+    def test_sync_get_news_signals_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_news_signals)
+        assert "/api/v1/news/signals" in source
+        assert "/api/v1/signals/news" not in source
+
+    def test_async_get_news_signals_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_news_signals)
+        assert "/api/v1/news/signals" in source
+        assert "/api/v1/signals/news" not in source
+
+    def test_sync_get_accuracy_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_accuracy)
+        assert "/api/v1/accuracy/me" in source
+        assert '"/api/v1/accuracy"' not in source
+
+    def test_async_get_accuracy_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_accuracy)
+        assert "/api/v1/accuracy/me" in source
+        assert '"/api/v1/accuracy"' not in source
+
+    def test_sync_get_portfolio_review_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_portfolio_review)
+        assert "/api/v1/ai/portfolio-review" in source
+        assert "/api/v1/portfolio/review" not in source
+
+    def test_async_get_portfolio_review_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_portfolio_review)
+        assert "/api/v1/ai/portfolio-review" in source
+        assert "/api/v1/portfolio/review" not in source
+
+    def test_sync_get_market_sentiment_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.get_market_sentiment)
+        assert "/api/v1/news/sentiment/" in source
+        assert "/api/v1/market-sentiment/" not in source
+
+    def test_async_get_market_sentiment_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.get_market_sentiment)
+        assert "/api/v1/news/sentiment/" in source
+        assert "/api/v1/market-sentiment/" not in source
+
+    def test_sync_provide_liquidity_path(self):
+        import inspect
+        source = inspect.getsource(PolyforgeClient.provide_liquidity)
+        assert "/api/v1/lp/provide" in source
+        assert "/api/v1/liquidity/provide" not in source
+
+    def test_async_provide_liquidity_path(self):
+        import inspect
+        source = inspect.getsource(AsyncPolyforgeClient.provide_liquidity)
+        assert "/api/v1/lp/provide" in source
+        assert "/api/v1/liquidity/provide" not in source
+
+    def test_sync_rollback_strategy_full_path(self):
+        """Platform path is /strategies/{id}/versions/{vid}/rollback, NOT /strategies/{id}/rollback/{vid}."""
+        import inspect
+        import re
+        source = inspect.getsource(PolyforgeClient.rollback_strategy)
+        assert re.search(r"/strategies/.*?/versions/.*?/rollback", source), (
+            "rollback_strategy must use path .../versions/{vid}/rollback, not .../rollback/{vid}"
+        )
+
+    def test_async_rollback_strategy_full_path(self):
+        """Platform path is /strategies/{id}/versions/{vid}/rollback, NOT /strategies/{id}/rollback/{vid}."""
+        import inspect
+        import re
+        source = inspect.getsource(AsyncPolyforgeClient.rollback_strategy)
+        assert re.search(r"/strategies/.*?/versions/.*?/rollback", source), (
+            "rollback_strategy must use path .../versions/{vid}/rollback, not .../rollback/{vid}"
+        )


### PR DESCRIPTION
## Summary

Issue #149 identified 12 SDK endpoint paths that didn't match platform routes (causing 404s). The path fixes themselves were already applied in prior commits (`6ee32f2`, `a813467`), but no regression tests existed to prevent silent reversion.

This PR adds `TestEndpointPathRegression` with sync + async `inspect.getsource()` path assertions for all 6 previously-untested corrections:

| Method | Wrong path (old) | Correct path (now tested) |
|---|---|---|
| `get_news_signals` | `/api/v1/signals/news` | `/api/v1/news/signals` |
| `get_accuracy` | `/api/v1/accuracy` | `/api/v1/accuracy/me` |
| `get_portfolio_review` | `/api/v1/portfolio/review` | `/api/v1/ai/portfolio-review` |
| `get_market_sentiment` | `/api/v1/market-sentiment/{id}` | `/api/v1/news/sentiment/{id}` |
| `provide_liquidity` | `/api/v1/liquidity/provide` | `/api/v1/lp/provide` |
| `rollback_strategy` | `/strategies/{id}/rollback/{vid}` | `/strategies/{id}/versions/{vid}/rollback` |

(Paths for `get_followed_whales`, marketplace routes, and copy-trading were already covered by existing tests.)

## Test plan

- [x] `TestEndpointPathRegression`: 12 tests, all pass
- [x] Full suite: 374 passed, 20 pre-existing `TestRiskSettings` failures (unrelated — `RiskSettings` not yet merged to master)
- [x] No new failures introduced

Closes #149