### PR TITLE
fix(models): rename Market.title to Market.question to match platform contract (#147)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -370,7 +370,7 @@ class PolyforgeClient:
         with PolyforgeClient(api_key="pk_...") as client:
             markets = client.list_markets(limit=5)
             for m in markets.items:
-                print(m.title, m.price)
+                print(m.question, m.price)
     """
 
     def __init__(
@@ -1936,7 +1936,7 @@ class AsyncPolyforgeClient:
         async with AsyncPolyforgeClient(api_key="pk_...") as client:
             markets = await client.list_markets(limit=5)
             for m in markets.items:
-                print(m.title, m.price)
+                print(m.question, m.price)
     """
 
     def __init__(

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -98,7 +98,7 @@ class Market:
     """A prediction market."""
 
     id: str = ""
-    title: str = ""
+    question: str = ""
     symbol: str = ""
     category: str = ""
     tokens: list[Token] = field(default_factory=list)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -338,26 +338,26 @@ class TestModelParsing:
         """Should instantiate Market model."""
         market = Market(
             id="btc-usd",
-            title="Bitcoin / US Dollar",
+            question="Bitcoin / US Dollar",
             symbol="BTC/USD",
             category="crypto",
             price=45000.0,
         )
         assert market.id == "btc-usd"
-        assert market.title == "Bitcoin / US Dollar"
+        assert market.question == "Bitcoin / US Dollar"
         assert market.price == 45000.0
 
-    def test_market_parses_title_from_api_response(self):
-        """Platform returns 'title' not 'name' — _parse must map it correctly (#43)."""
+    def test_market_parses_question_from_api_response(self):
+        """Platform returns 'question' not 'title' — _parse must map it correctly (#147)."""
         api_response = {
             "id": "0xabc",
-            "title": "Will BTC reach $100K by June?",
+            "question": "Will BTC reach $100K by June?",
             "symbol": "BTC-100K",
             "category": "Crypto",
             "price": 0.65,
         }
         market = _parse(Market, api_response)
-        assert market.title == "Will BTC reach $100K by June?"
+        assert market.question == "Will BTC reach $100K by June?"
         assert market.id == "0xabc"
 
     def test_strategy_model_instantiation(self):
@@ -488,7 +488,7 @@ class TestTokenModel:
         """_parse must recursively build Token objects from Market.tokens array."""
         raw = {
             "id": "mkt-001",
-            "title": "Will ETH flip BTC by 2025?",
+            "question": "Will ETH flip BTC by 2025?",
             "tokens": [
                 {"id": "tok-yes", "outcome": "YES", "price": 0.35},
                 {"id": "tok-no", "outcome": "NO", "price": 0.65},
@@ -506,7 +506,7 @@ class TestTokenModel:
         assert no_tok.price == 0.65
 
     def test_market_parses_empty_tokens_array(self):
-        raw = {"id": "mkt-002", "title": "Test", "tokens": []}
+        raw = {"id": "mkt-002", "question": "Test", "tokens": []}
         market = _parse(Market, raw)
         assert market.tokens == []
 


### PR DESCRIPTION
## Summary

- Platform API returns market names under the key `question`; the SDK `Market` dataclass had a `title` field which silently dropped the value during deserialization (`_parse` does a direct field-name lookup — mismatch yields `""` with no error)
- Renames `Market.title` → `Market.question` in `models.py`
- Updates docstring usage examples in both sync and async client classes
- Updates all affected tests (constructor calls, raw-dict fixtures, assertions)

Fixes #147 / POLA-345

## Test plan

- [ ] All 371 existing tests pass (`pytest tests/test_client.py`)
- [ ] `test_market_parses_question_from_api_response` confirms `"question"` key from API maps to `market.question`
- [ ] No `Market.title` references remain in source or tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)