### PR TITLE
fix: add POST_ONLY to valid order types

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -276,7 +276,7 @@ _VALID_MODES = frozenset({"live", "paper"})
 _VALID_DEPLOYMENT_MODES = frozenset({"LIVE", "SIMULATION"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
-_VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK"})
+_VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "POST_ONLY"})
 
 
 def _validate_financial_param(name: str, value: float) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ from polyforge.client import (
     _validate_webhook_url,
     _is_ip_blocked,
     _resolve_and_validate_ips,
+    _VALID_ORDER_TYPES,
 )
 from polyforge.errors import (
     PolyforgeError,
@@ -823,6 +824,15 @@ class TestEnumValidation:
         client = PolyforgeClient(api_key="test-key")
         with pytest.raises(ValueError, match="must be one of"):
             client.place_order("tok", "BUY", "YES", 10.0, 0.5, order_type="IOC")
+
+    def test_valid_order_types_match_platform_dto(self):
+        """SDK order types must include all values from platform's OrderTypeDto."""
+        platform_order_types = {"GTC", "GTD", "FOK", "POST_ONLY"}
+        assert _VALID_ORDER_TYPES == platform_order_types
+
+    def test_place_order_accepts_post_only(self):
+        """POST_ONLY is a valid platform order type — SDK must not reject it."""
+        _validate_enum("order_type", "POST_ONLY", _VALID_ORDER_TYPES)
 
 
 class TestPlaceOrderValidation:


### PR DESCRIPTION
## Summary

- Added `POST_ONLY` to `_VALID_ORDER_TYPES` frozenset in `client.py` to match the platform's `OrderTypeDto` enum
- Added contract test asserting SDK order types equal platform DTO values
- Added behavioral test confirming `POST_ONLY` passes validation

Closes #157

## Test plan

- [x] New test `test_valid_order_types_match_platform_dto` — asserts enum parity with platform
- [x] New test `test_place_order_accepts_post_only` — verifies no ValueError on POST_ONLY
- [x] Full test suite passes (401 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)