### PR TITLE
fix(license): correct PyPI classifier from MIT to Apache-2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Fixed stale `License :: OSI Approved :: MIT License` classifier in `pyproject.toml`
- Changed to `License :: OSI Approved :: Apache Software License` to match the actual Apache-2.0 license (migrated in commit 4082e4d / POLA-241)
- One-line change — LICENSE, NOTICE, and README were already correct

## Test plan
- [ ] Verify `pyproject.toml` classifier reads Apache, not MIT
- [ ] Confirm `pip install -e .` still works
- [ ] Check PyPI page after next publish shows correct license

🤖 Generated with [Claude Code](https://claude.com/claude-code)