### PR TITLE
fix: send {mode} instead of {paperMode} in start_strategy (closes #196)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -324,7 +324,6 @@ def _validate_enum(name: str, value: str, allowed: frozenset[str]) -> None:
 
 
 _VALID_MODES = frozenset({"live", "paper"})
-_VALID_DEPLOYMENT_MODES = frozenset({"LIVE", "SIMULATION"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
 _VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "POST_ONLY"})
@@ -859,13 +858,9 @@ class PolyforgeClient:
             body["marketId"] = market_id
         return _parse(Strategy, self._post("/api/v1/strategies/from-description", json=body))
 
-    def start_strategy(self, strategy_id: str, paper_mode: bool = True,
-                       deployment_mode: str | None = None) -> StrategyStatusResponse:
-        body: dict[str, Any] = {"paperMode": paper_mode}
-        if deployment_mode is not None:
-            _validate_enum("deploymentMode", deployment_mode, _VALID_DEPLOYMENT_MODES)
-            body["deploymentMode"] = deployment_mode
-        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json=body))
+    def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
+        _validate_enum("mode", mode, _VALID_MODES)
+        return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))
@@ -3173,13 +3168,9 @@ class AsyncPolyforgeClient:
             body["marketId"] = market_id
         return _parse(Strategy, await self._post("/api/v1/strategies/from-description", json=body))
 
-    async def start_strategy(self, strategy_id: str, paper_mode: bool = True,
-                             deployment_mode: str | None = None) -> StrategyStatusResponse:
-        body: dict[str, Any] = {"paperMode": paper_mode}
-        if deployment_mode is not None:
-            _validate_enum("deploymentMode", deployment_mode, _VALID_DEPLOYMENT_MODES)
-            body["deploymentMode"] = deployment_mode
-        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json=body))
+    async def start_strategy(self, strategy_id: str, mode: str = "paper") -> StrategyStatusResponse:
+        _validate_enum("mode", mode, _VALID_MODES)
+        return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/start", json={"mode": mode}))
 
     async def stop_strategy(self, strategy_id: str) -> StrategyStatusResponse:
         return _parse(StrategyStatusResponse, await self._post(f"/api/v1/strategies/{_encode_path(strategy_id)}/stop"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -749,13 +749,13 @@ class TestPlatformContractCompliance:
         source = inspect.getsource(PolyforgeClient.create_strategy_from_description)
         assert '"description"' in source or "'description'" in source
 
-    def test_start_strategy_sends_paper_mode_field(self):
-        """start_strategy() must send paperMode boolean, not {mode} string (#150)."""
+    def test_start_strategy_sends_mode_field(self):
+        """start_strategy() must send {mode: 'live'|'paper'} to match platform contract (#196)."""
         import inspect
 
         source = inspect.getsource(PolyforgeClient.start_strategy)
-        assert "paperMode" in source, "start_strategy() must send 'paperMode' field to match platform contract"
-        assert '"mode"' not in source and "'mode'" not in source, "start_strategy() must not send legacy 'mode' field"
+        assert '"mode"' in source or "'mode'" in source, "start_strategy() must send 'mode' field"
+        assert "paperMode" not in source, "start_strategy() must not send obsolete 'paperMode' field"
 
 
 class TestFinancialParamValidation:
@@ -807,10 +807,10 @@ class TestEnumValidation:
         with pytest.raises(ValueError, match="must be one of"):
             _validate_enum("side", "HOLD", frozenset({"BUY", "SELL"}))
 
-    def test_start_strategy_rejects_invalid_deployment_mode(self):
+    def test_start_strategy_rejects_invalid_mode(self):
         client = PolyforgeClient(api_key="test-key")
         with pytest.raises(ValueError, match="must be one of"):
-            client.start_strategy("s-1", deployment_mode="turbo")
+            client.start_strategy("s-1", mode="turbo")
 
     def test_place_order_rejects_invalid_side(self):
         client = PolyforgeClient(api_key="test-key")


### PR DESCRIPTION
## Summary

- Changed `start_strategy()` (sync + async) to send `{"mode": "live"|"paper"}` instead of `{"paperMode": bool, "deploymentMode"?: string}`
- Platform contract now expects `{mode}` — the old `{paperMode}` payload caused 100% failure rate
- Removed dead `_VALID_DEPLOYMENT_MODES` constant
- Updated tests to verify new payload format

## Test plan

- [x] All 703 existing tests pass
- [x] `test_start_strategy_sends_mode_field` verifies `mode` field is present and `paperMode` is absent
- [x] `test_start_strategy_rejects_invalid_mode` verifies enum validation

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)