### PR TITLE
fix(security): add NaN/Inf guards and financial param validation

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -262,7 +262,12 @@ def _parse(cls: type[T], data: dict[str, Any]) -> T:
             else:
                 kwargs[f.name] = raw
         elif hint is float and isinstance(raw, str):
-            kwargs[f.name] = float(raw)
+            val = float(raw)
+            if not math.isfinite(val):
+                raise ValueError(
+                    f"Non-finite float value for {f.name}: {raw!r}"
+                )
+            kwargs[f.name] = val
         else:
             kwargs[f.name] = raw
 
@@ -1294,6 +1299,7 @@ class PolyforgeClient:
         if drawdown_lookback_hours is not None:
             body["drawdownLookbackHours"] = drawdown_lookback_hours
         if drawdown_threshold_pct is not None:
+            _validate_financial_param("drawdown_threshold_pct", drawdown_threshold_pct)
             body["drawdownThresholdPct"] = drawdown_threshold_pct
         data = self._patch("/api/v1/settings/risk", json=body)
         return RiskSettings(
@@ -1461,6 +1467,7 @@ class PolyforgeClient:
         Args:
             min_margin: Minimum profit margin percentage to include (default 0.5%).
         """
+        _validate_financial_param("min_margin", min_margin)
         data = self._get("/api/v1/arbitrage", params={"minMargin": min_margin})
         return [ArbitrageOpportunity(
             market_id=o.get("marketId", ""),
@@ -1481,11 +1488,13 @@ class PolyforgeClient:
 
     def get_cross_venue_opportunities(self, *, min_spread: float = 3.0) -> list[CrossVenueOpportunity]:
         """List cross-venue arbitrage opportunities between Polymarket and Kalshi."""
+        _validate_financial_param("min_spread", min_spread)
         data = self._get("/api/v1/arbitrage/cross-venue", params={"minSpread": min_spread})
         return [_parse(CrossVenueOpportunity, o) for o in data]
 
     def get_cross_venue_opportunities_for_market(self, market_id: str, *, min_spread: float = 3.0) -> list[CrossVenueOpportunity]:
         """Cross-venue arbitrage opportunities involving a specific market."""
+        _validate_financial_param("min_spread", min_spread)
         data = self._get(f"/api/v1/arbitrage/cross-venue/{quote(market_id, safe='')}", params={"minSpread": min_spread})
         return [_parse(CrossVenueOpportunity, o) for o in data]
 
@@ -1531,6 +1540,7 @@ class PolyforgeClient:
 
     def create_arbitrage_alert(self, *, min_spread_pct: float, market_id: str | None = None) -> ArbitrageAlertSubscription:
         """Create an arbitrage alert subscription."""
+        _validate_financial_param("min_spread_pct", min_spread_pct)
         body: dict[str, Any] = {"minSpreadPct": str(min_spread_pct)}
         if market_id is not None:
             body["marketId"] = market_id
@@ -3584,6 +3594,7 @@ class AsyncPolyforgeClient:
         if drawdown_lookback_hours is not None:
             body["drawdownLookbackHours"] = drawdown_lookback_hours
         if drawdown_threshold_pct is not None:
+            _validate_financial_param("drawdown_threshold_pct", drawdown_threshold_pct)
             body["drawdownThresholdPct"] = drawdown_threshold_pct
         data = await self._patch("/api/v1/settings/risk", json=body)
         return RiskSettings(
@@ -3747,6 +3758,7 @@ class AsyncPolyforgeClient:
 
     async def get_arbitrage_opportunities(self, *, min_margin: float = 0.5) -> list[ArbitrageOpportunity]:
         """Scan all markets for merge arbitrage opportunities (YES + NO < $1.00)."""
+        _validate_financial_param("min_margin", min_margin)
         data = await self._get("/api/v1/arbitrage", params={"minMargin": min_margin})
         return [ArbitrageOpportunity(
             market_id=o.get("marketId", ""),
@@ -3767,11 +3779,13 @@ class AsyncPolyforgeClient:
 
     async def get_cross_venue_opportunities(self, *, min_spread: float = 3.0) -> list[CrossVenueOpportunity]:
         """List cross-venue arbitrage opportunities between Polymarket and Kalshi."""
+        _validate_financial_param("min_spread", min_spread)
         data = await self._get("/api/v1/arbitrage/cross-venue", params={"minSpread": min_spread})
         return [_parse(CrossVenueOpportunity, o) for o in data]
 
     async def get_cross_venue_opportunities_for_market(self, market_id: str, *, min_spread: float = 3.0) -> list[CrossVenueOpportunity]:
         """Cross-venue arbitrage opportunities involving a specific market."""
+        _validate_financial_param("min_spread", min_spread)
         data = await self._get(f"/api/v1/arbitrage/cross-venue/{quote(market_id, safe='')}", params={"minSpread": min_spread})
         return [_parse(CrossVenueOpportunity, o) for o in data]
 
@@ -3817,6 +3831,7 @@ class AsyncPolyforgeClient:
 
     async def create_arbitrage_alert(self, *, min_spread_pct: float, market_id: str | None = None) -> ArbitrageAlertSubscription:
         """Create an arbitrage alert subscription."""
+        _validate_financial_param("min_spread_pct", min_spread_pct)
         body: dict[str, Any] = {"minSpreadPct": str(min_spread_pct)}
         if market_id is not None:
             body["marketId"] = market_id

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5433,3 +5433,200 @@ class TestPutHelper:
 
     def test_async_put_exists(self):
         assert hasattr(AsyncPolyforgeClient, "_put")
+
+
+class TestParseNonFiniteFloats:
+    """_parse() must reject non-finite float strings (#201)."""
+
+    def test_parse_rejects_nan_string(self):
+        """float('nan') should be rejected during parsing."""
+        import dataclasses
+
+        @dataclasses.dataclass
+        class FakeModel:
+            price: float = 0.0
+
+        with pytest.raises(ValueError, match="Non-finite"):
+            _parse(FakeModel, {"price": "nan"})
+
+    def test_parse_rejects_inf_string(self):
+        """float('inf') should be rejected during parsing."""
+        import dataclasses
+
+        @dataclasses.dataclass
+        class FakeModel:
+            price: float = 0.0
+
+        with pytest.raises(ValueError, match="Non-finite"):
+            _parse(FakeModel, {"price": "inf"})
+
+    def test_parse_rejects_negative_inf_string(self):
+        """float('-inf') should be rejected during parsing."""
+        import dataclasses
+
+        @dataclasses.dataclass
+        class FakeModel:
+            price: float = 0.0
+
+        with pytest.raises(ValueError, match="Non-finite"):
+            _parse(FakeModel, {"price": "-inf"})
+
+    def test_parse_accepts_normal_float_string(self):
+        """Normal numeric strings should still parse correctly."""
+        import dataclasses
+
+        @dataclasses.dataclass
+        class FakeModel:
+            price: float = 0.0
+
+        result = _parse(FakeModel, {"price": "1.23"})
+        assert result.price == 1.23
+
+
+class TestArbitrageParamValidation:
+    """Arbitrage and risk-settings methods must validate financial params (#200)."""
+
+    def test_get_arbitrage_opportunities_rejects_nan(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="NaN"):
+            client.get_arbitrage_opportunities(min_margin=float("nan"))
+        client.close()
+
+    def test_get_arbitrage_opportunities_rejects_inf(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="Infinity"):
+            client.get_arbitrage_opportunities(min_margin=float("inf"))
+        client.close()
+
+    def test_get_arbitrage_opportunities_rejects_negative(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="positive"):
+            client.get_arbitrage_opportunities(min_margin=-1.0)
+        client.close()
+
+    def test_get_cross_venue_opportunities_rejects_inf(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="Infinity"):
+            client.get_cross_venue_opportunities(min_spread=float("inf"))
+        client.close()
+
+    def test_get_cross_venue_opportunities_rejects_nan(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="NaN"):
+            client.get_cross_venue_opportunities(min_spread=float("nan"))
+        client.close()
+
+    def test_get_cross_venue_opportunities_for_market_rejects_nan(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="NaN"):
+            client.get_cross_venue_opportunities_for_market("m1", min_spread=float("nan"))
+        client.close()
+
+    def test_create_arbitrage_alert_rejects_negative(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="positive"):
+            client.create_arbitrage_alert(min_spread_pct=-1.0)
+        client.close()
+
+    def test_create_arbitrage_alert_rejects_nan(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="NaN"):
+            client.create_arbitrage_alert(min_spread_pct=float("nan"))
+        client.close()
+
+    def test_update_risk_settings_rejects_nan_threshold(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="NaN"):
+            client.update_risk_settings(drawdown_threshold_pct=float("nan"))
+        client.close()
+
+    def test_update_risk_settings_rejects_inf_threshold(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="Infinity"):
+            client.update_risk_settings(drawdown_threshold_pct=float("inf"))
+        client.close()
+
+    def test_update_risk_settings_rejects_negative_threshold(self):
+        client = PolyforgeClient(api_key="test-key")
+        with pytest.raises(ValueError, match="positive"):
+            client.update_risk_settings(drawdown_threshold_pct=-5.0)
+        client.close()
+
+    def test_update_risk_settings_skips_validation_when_none(self):
+        """None values should not trigger validation — only supplied fields are validated."""
+        from unittest.mock import MagicMock
+        client = PolyforgeClient(api_key="test-key")
+        client._patch = MagicMock(return_value={
+            "drawdownEnabled": True,
+            "drawdownLookbackHours": 24,
+            "drawdownThresholdPct": "0.1",
+            "circuitBreakerTripped": False,
+            "circuitBreakerTrippedAt": None,
+        })
+        result = client.update_risk_settings(drawdown_enabled=True)
+        assert result.drawdown_enabled is True
+        client.close()
+
+    def test_async_get_arbitrage_opportunities_rejects_nan(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            with pytest.raises(ValueError, match="NaN"):
+                await client.get_arbitrage_opportunities(min_margin=float("nan"))
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_get_cross_venue_opportunities_rejects_inf(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            with pytest.raises(ValueError, match="Infinity"):
+                await client.get_cross_venue_opportunities(min_spread=float("inf"))
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_create_arbitrage_alert_rejects_negative(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            with pytest.raises(ValueError, match="positive"):
+                await client.create_arbitrage_alert(min_spread_pct=-1.0)
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_update_risk_settings_rejects_nan_threshold(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            with pytest.raises(ValueError, match="NaN"):
+                await client.update_risk_settings(drawdown_threshold_pct=float("nan"))
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_update_risk_settings_skips_validation_when_none(self):
+        """None drawdown_threshold_pct must not trigger validation in async client."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._patch = AsyncMock(return_value={
+                "drawdownEnabled": True,
+                "drawdownLookbackHours": 24,
+                "drawdownThresholdPct": "0.1",
+                "circuitBreakerTripped": False,
+                "circuitBreakerTrippedAt": None,
+            })
+            result = await client.update_risk_settings(drawdown_enabled=True)
+            assert result.drawdown_enabled is True
+            await client.close()
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary
- **GH #201**: `_parse()` accepted "nan"/"inf" strings when converting to float. Now rejects non-finite values with `math.isfinite()` check
- **GH #200**: `arbitrage_*` and `risk_settings_*` methods skipped `_validate_financial_param()`. Added validation to all 5 sync + 5 async methods that accept float parameters

## Test plan
- [x] Verify `_parse()` rejects "nan", "inf", "-inf" string values
- [x] Verify `_parse()` still accepts normal decimal strings
- [x] Verify arbitrage methods reject NaN/Inf/negative params (sync + async)
- [x] Verify `update_risk_settings` skips validation for None params
- [x] `pytest tests/ -v` passes — 723 tests, 0 failures (21 new tests added)

Closes #200
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)