### PR TITLE
fix(security): validate trading and copy numeric request fields

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -350,6 +350,46 @@ def _validate_financial_param(name: str, value: float) -> None:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
+def _numberish_to_float(name: str, value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must be a number, got {type(value).__name__}") from exc
+
+
+def _validate_positive_numberish_param(name: str, value: float | str) -> None:
+    _validate_financial_param(name, _numberish_to_float(name, value))
+
+
+def _validate_finite_numberish_param(name: str, value: float | str) -> None:
+    number = _numberish_to_float(name, value)
+    if math.isnan(number):
+        raise ValueError(f"{name} must not be NaN")
+    if math.isinf(number):
+        raise ValueError(f"{name} must not be Infinity")
+
+
+def _validate_batch_order(order: dict[str, Any]) -> None:
+    if "side" in order:
+        _validate_enum("side", order["side"], _VALID_SIDES)
+    if "outcome" in order:
+        _validate_enum("outcome", order["outcome"], _VALID_OUTCOMES)
+    if "orderType" in order:
+        _validate_enum("order_type", order["orderType"], _VALID_ORDER_TYPES)
+    if "size" in order:
+        _validate_positive_numberish_param("size", order["size"])
+    if "price" in order:
+        _validate_positive_numberish_param("price", order["price"])
+
+
+def _validate_copy_config_numeric_fields(fields: dict[str, Any]) -> None:
+    for name in ("sizeValue", "maxExposure", "maxDailyLoss"):
+        if name in fields and fields[name] is not None:
+            _validate_positive_numberish_param(name, fields[name])
+    if "priceOffset" in fields and fields["priceOffset"] is not None:
+        _validate_finite_numberish_param("priceOffset", fields["priceOffset"])
+
+
 _BLOCKED_HOSTNAMES: set[str] = {
     "localhost",
     "metadata.google.internal",
@@ -1378,6 +1418,8 @@ class PolyforgeClient:
             raise ValueError("batch_orders requires at least 1 order")
         if len(orders) > 15:
             raise ValueError("batch_orders accepts at most 15 orders per call")
+        for order in orders:
+            _validate_batch_order(order)
         data = self._post("/api/v1/orders/batch", json={"orders": orders})
         items = [
             BatchOrderItem(
@@ -1410,6 +1452,7 @@ class PolyforgeClient:
         """Close an open position (sell all shares at market price)."""
         body: dict[str, Any] = {"tokenId": token_id}
         if size is not None:
+            _validate_positive_numberish_param("size", size)
             body["size"] = str(size)
         data = self._post("/api/v1/orders/close-position", json=body)
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -1444,6 +1487,7 @@ class PolyforgeClient:
             token_id: The token to split.
             amount: The amount to split (sent as a NumberString).
         """
+        _validate_positive_numberish_param("amount", amount)
         amount_str = str(amount)
         data = self._post("/api/v1/orders/split", json={"tokenId": token_id, "amount": amount_str})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -1455,6 +1499,7 @@ class PolyforgeClient:
             token_id: The token to merge.
             amount: The amount to merge (sent as a NumberString).
         """
+        _validate_positive_numberish_param("amount", amount)
         amount_str = str(amount)
         data = self._post("/api/v1/orders/merge", json={"tokenId": token_id, "amount": amount_str})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -1997,6 +2042,8 @@ class PolyforgeClient:
         Returns:
             The upserted :class:`WhaleAlertFilter`.
         """
+        if min_size is not None:
+            _validate_positive_numberish_param("min_size", min_size)
         body = _strip_none({
             "minSize": min_size,
             "marketIds": market_ids,
@@ -2287,6 +2334,7 @@ class PolyforgeClient:
             body["maxDailyLoss"] = max_daily_loss
         if price_offset is not None:
             body["priceOffset"] = price_offset
+        _validate_copy_config_numeric_fields(body)
         return _parse(CopyConfig, self._post("/api/v1/copy", json=body))
 
     def get_copy_config(self, copy_id: str) -> CopyConfig:
@@ -2314,6 +2362,7 @@ class PolyforgeClient:
         Returns:
             The updated :class:`CopyConfig`.
         """
+        _validate_copy_config_numeric_fields(kwargs)
         return _parse(
             CopyConfig,
             self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=kwargs),
@@ -3673,6 +3722,8 @@ class AsyncPolyforgeClient:
             raise ValueError("batch_orders requires at least 1 order")
         if len(orders) > 15:
             raise ValueError("batch_orders accepts at most 15 orders per call")
+        for order in orders:
+            _validate_batch_order(order)
         data = await self._post("/api/v1/orders/batch", json={"orders": orders})
         items = [
             BatchOrderItem(
@@ -3705,6 +3756,7 @@ class AsyncPolyforgeClient:
         """Close an open position (sell all shares at market price)."""
         body: dict[str, Any] = {"tokenId": token_id}
         if size is not None:
+            _validate_positive_numberish_param("size", size)
             body["size"] = str(size)
         data = await self._post("/api/v1/orders/close-position", json=body)
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -3739,6 +3791,7 @@ class AsyncPolyforgeClient:
             token_id: The token to split.
             amount: The amount to split (sent as a NumberString).
         """
+        _validate_positive_numberish_param("amount", amount)
         amount_str = str(amount)
         data = await self._post("/api/v1/orders/split", json={"tokenId": token_id, "amount": amount_str})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -3750,6 +3803,7 @@ class AsyncPolyforgeClient:
             token_id: The token to merge.
             amount: The amount to merge (sent as a NumberString).
         """
+        _validate_positive_numberish_param("amount", amount)
         amount_str = str(amount)
         data = await self._post("/api/v1/orders/merge", json={"tokenId": token_id, "amount": amount_str})
         return PlaceOrderResponse(order_id=data["orderId"], intent_id=data["intentId"], status=data["status"])
@@ -4172,6 +4226,8 @@ class AsyncPolyforgeClient:
         active: bool | None = None,
     ) -> WhaleAlertFilter:
         """Create or update the current user's whale alert filter."""
+        if min_size is not None:
+            _validate_positive_numberish_param("min_size", min_size)
         body = _strip_none({
             "minSize": min_size,
             "marketIds": market_ids,
@@ -4443,6 +4499,7 @@ class AsyncPolyforgeClient:
             body["maxDailyLoss"] = max_daily_loss
         if price_offset is not None:
             body["priceOffset"] = price_offset
+        _validate_copy_config_numeric_fields(body)
         return _parse(CopyConfig, await self._post("/api/v1/copy", json=body))
 
     async def get_copy_config(self, copy_id: str) -> CopyConfig:
@@ -4452,6 +4509,7 @@ class AsyncPolyforgeClient:
 
     async def update_copy_config(self, copy_id: str, **kwargs: Any) -> CopyConfig:
         """Update an existing copy-trading configuration."""
+        _validate_copy_config_numeric_fields(kwargs)
         return _parse(
             CopyConfig,
             await self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=kwargs),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3829,6 +3829,30 @@ class TestBulkOrderEndpoints:
             client.batch_orders([{"tokenId": f"t{i}"} for i in range(16)])
         client.close()
 
+    def test_batch_orders_rejects_nan_order_size(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="NaN"):
+            client.batch_orders([{
+                "tokenId": "tok",
+                "side": "BUY",
+                "outcome": "YES",
+                "size": float("nan"),
+                "price": 0.5,
+            }])
+        client.close()
+
+    def test_batch_orders_rejects_invalid_order_enum(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="must be one of"):
+            client.batch_orders([{
+                "tokenId": "tok",
+                "side": "HOLD",
+                "outcome": "YES",
+                "size": 10,
+                "price": 0.5,
+            }])
+        client.close()
+
     def test_bulk_cancel_orders_validates_minimum(self):
         client = PolyforgeClient(api_key="test")
         with pytest.raises(ValueError, match="at least 1"):
@@ -5627,6 +5651,152 @@ class TestArbitrageParamValidation:
             })
             result = await client.update_risk_settings(drawdown_enabled=True)
             assert result.drawdown_enabled is True
+            await client.close()
+
+        asyncio.run(_run())
+
+
+class TestTradingCopyNumericValidation:
+    """Trading and copy endpoints reject malformed numeric request fields (#204)."""
+
+    @pytest.mark.parametrize("method_name,arg_name", [
+        ("close_position", "size"),
+        ("split_position", "amount"),
+        ("merge_positions", "amount"),
+    ])
+    def test_position_methods_reject_non_finite_number_strings(self, method_name, arg_name):
+        client = PolyforgeClient(api_key="test")
+        kwargs = {arg_name: "Infinity"}
+        with pytest.raises(ValueError, match="Infinity"):
+            getattr(client, method_name)("tok", **kwargs)
+        client.close()
+
+    @pytest.mark.parametrize("method_name,arg_name", [
+        ("close_position", "size"),
+        ("split_position", "amount"),
+        ("merge_positions", "amount"),
+    ])
+    def test_position_methods_reject_negative_number_strings(self, method_name, arg_name):
+        client = PolyforgeClient(api_key="test")
+        kwargs = {arg_name: "-1"}
+        with pytest.raises(ValueError, match="positive"):
+            getattr(client, method_name)("tok", **kwargs)
+        client.close()
+
+    def test_set_whale_alert_filter_rejects_nan_min_size(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="NaN"):
+            client.set_whale_alert_filter(min_size="NaN")
+        client.close()
+
+    @pytest.mark.parametrize("field,kwargs", [
+        ("size_value", {"size_value": float("nan")}),
+        ("max_exposure", {"max_exposure": float("inf")}),
+        ("max_daily_loss", {"max_daily_loss": -1.0}),
+    ])
+    def test_create_copy_config_rejects_invalid_positive_numeric_fields(self, field, kwargs):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="NaN|Infinity|positive"):
+            client.create_copy_config("0x0000000000000000000000000000000000000001", **kwargs)
+        client.close()
+
+    def test_create_copy_config_rejects_non_finite_price_offset(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="Infinity"):
+            client.create_copy_config(
+                "0x0000000000000000000000000000000000000001",
+                price_offset=float("-inf"),
+            )
+        client.close()
+
+    def test_create_copy_config_allows_negative_price_offset(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._post = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "PERCENTAGE",
+            "sizeValue": "10",
+            "maxExposure": "500",
+            "maxDailyLoss": "100",
+            "priceOffset": "-0.5",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+        client.create_copy_config(
+            "0x0000000000000000000000000000000000000001",
+            price_offset=-0.5,
+        )
+        client._post.assert_called_once()
+        assert client._post.call_args.kwargs["json"]["priceOffset"] == -0.5
+        client.close()
+
+    def test_update_copy_config_rejects_invalid_numeric_kwargs(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="Infinity"):
+            client.update_copy_config("copy-1", maxExposure="Infinity")
+        client.close()
+
+    def test_update_copy_config_allows_negative_price_offset(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "PERCENTAGE",
+            "sizeValue": "10",
+            "maxExposure": "500",
+            "maxDailyLoss": "100",
+            "priceOffset": "-0.5",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+        client.update_copy_config("copy-1", priceOffset=-0.5)
+        client._patch.assert_called_once()
+        assert client._patch.call_args.kwargs["json"]["priceOffset"] == -0.5
+        client.close()
+
+    def test_async_batch_orders_rejects_infinite_order_price(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            with pytest.raises(ValueError, match="Infinity"):
+                await client.batch_orders([{
+                    "tokenId": "tok",
+                    "side": "BUY",
+                    "outcome": "YES",
+                    "size": 10,
+                    "price": float("inf"),
+                }])
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_copy_and_whale_paths_validate_before_awaiting(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            with pytest.raises(ValueError, match="NaN"):
+                await client.set_whale_alert_filter(min_size="NaN")
+            with pytest.raises(ValueError, match="positive"):
+                await client.create_copy_config(
+                    "0x0000000000000000000000000000000000000001",
+                    max_daily_loss=0,
+                )
+            with pytest.raises(ValueError, match="Infinity"):
+                await client.update_copy_config("copy-1", priceOffset="Infinity")
             await client.close()
 
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
- validates batch order enums plus per-order `size`/`price` before posting
- validates close/split/merge position numeric strings before stringifying request bodies
- validates whale alert `minSize` and copy config numeric fields in sync and async clients
- treats `priceOffset` as signed but finite, matching the platform `+/- % from source price` contract

Closes #204.

## Verification
- `uv run --with pytest pytest tests/test_client.py::TestBulkOrderEndpoints::test_batch_orders_rejects_nan_order_size tests/test_client.py::TestBulkOrderEndpoints::test_batch_orders_rejects_invalid_order_enum tests/test_client.py::TestTradingCopyNumericValidation -q` -> 18 passed
- `uv run --with pytest pytest -q` -> 741 passed
- `uv build` -> built sdist and wheel
- added-line security scan for secrets/shell/eval/pickle/SQL patterns -> no findings

## Notes
- `uv run --with ruff ruff check .` still reports existing baseline lint issues in untouched code, including unused imports, duplicate `TestNewModels`, and one-line `if` statements in smart-order paths.
