### PR TITLE
feat(sports): add 9 sports markets endpoints (POLA-1847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+**Sports API (POLA-1847)** — nine endpoints wrapping the `/api/v1/sports/*`
+controller, available on both `PolyforgeClient` and `AsyncPolyforgeClient`:
+
+- `list_sports_categories()` → `list[dict[str, Any]]`
+- `list_sports_markets(*, page, limit, category, search, series_ticker, event_ticker, live_only, sort)` → `PaginatedResponse[dict[str, Any]]`
+- `list_sports_events(*, page, limit, category, series_ticker, status)` → `PaginatedResponse[dict[str, Any]]`
+- `get_sports_event(event_ticker)` → `dict[str, Any]` shaped `{event, markets[]}`
+- `list_sports_milestones(*, page, limit, event_ticker, status)` → `dict[str, Any]` shaped `{milestones, cursor}`
+- `get_sports_live_data(milestone_id)` → `dict[str, Any]` shaped `{liveData}`
+- `list_sports_combos(*, page, limit, series_ticker)` → `dict[str, Any]` shaped `{collections, cursor}`
+- `get_sports_combo_collection(collection_ticker)` → `dict[str, Any]` (server currently ignores the ticker — wrapped as-is)
+- `lookup_sports_combo(collection_ticker, selected_markets)` → `dict[str, Any] | None`
+
+`sort` and event `status` are validated client-side against the controller enums
+(`{"volume", "closing_soon", "newest"}` and
+`{"SCHEDULED", "PREGAME", "LIVE", "HALFTIME", "FINAL"}` respectively). Path
+parameters (`event_ticker`, `milestone_id`, `collection_ticker`) are URL-encoded
+via `_encode_path` to prevent path-traversal injection.
+
+Responses mirror the upstream controller's permissive shape (`Record<string,
+unknown>` → `dict[str, Any]`) intentionally — see parent issue for the rationale.
+
 ## [2.0.0] — 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ asyncio.run(main())
 | `get_whale_feed(min_size)` | Get large on-chain trades |
 | `get_news_signals(min_confidence)` | Get AI-generated news trading signals |
 
+### Sports Markets
+
+| Method | Description |
+|--------|-------------|
+| `list_sports_categories()` | List sports categories with series tickers and market counts |
+| `list_sports_markets(page, limit, category, search, series_ticker, event_ticker, live_only, sort)` | List sports markets — `sort` ∈ `{"volume", "closing_soon", "newest"}` |
+| `list_sports_events(page, limit, category, series_ticker, status)` | List sports events — `status` ∈ `{"SCHEDULED", "PREGAME", "LIVE", "HALFTIME", "FINAL"}` |
+| `get_sports_event(event_ticker)` | Fetch one event with its markets |
+| `list_sports_milestones(page, limit, event_ticker, status)` | List in-game milestones (cursor-paginated) |
+| `get_sports_live_data(milestone_id)` | Fetch live data for a milestone |
+| `list_sports_combos(page, limit, series_ticker)` | List combo collections (cursor-paginated) |
+| `get_sports_combo_collection(collection_ticker)` | Fetch a combo collection by ticker |
+| `lookup_sports_combo(collection_ticker, selected_markets)` | Resolve `(eventTicker, marketTicker)` for a combo selection |
+
 ### Configuration
 
 | Method | Description |

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -331,6 +331,10 @@ _VALID_MODES = frozenset({"live", "paper"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
 _VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "POST_ONLY"})
+_VALID_SPORTS_SORTS = frozenset({"volume", "closing_soon", "newest"})
+_VALID_SPORTS_EVENT_STATUSES = frozenset(
+    {"SCHEDULED", "PREGAME", "LIVE", "HALFTIME", "FINAL"}
+)
 
 
 def _validate_financial_param(name: str, value: float) -> None:
@@ -2822,6 +2826,218 @@ class PolyforgeClient:
             self._patch("/api/v1/users/me/venue-preferences", json=body),
         )
 
+    # -- Sports Markets --
+
+    def list_sports_categories(self) -> list[dict[str, Any]]:
+        """List sports market categories.
+
+        Returns:
+            A list of category descriptors. Each item carries at least
+            ``category``, ``label``, ``seriesTickers`` (list of strings) and
+            ``marketCount``. Additional fields may be present and are returned
+            as-is to mirror the controller's permissive shape.
+        """
+        data = self._get("/api/v1/sports/categories")
+        return list(data) if isinstance(data, list) else []
+
+    def list_sports_markets(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        category: str | None = None,
+        search: str | None = None,
+        series_ticker: str | None = None,
+        event_ticker: str | None = None,
+        live_only: bool | None = None,
+        sort: str | None = None,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List sports markets with optional filters.
+
+        Args:
+            page: 1-based page index (default ``1``).
+            limit: Page size (default ``10``).
+            category: Filter by category slug (max length 50).
+            search: Free-text search across title/slug.
+            series_ticker: Filter by Kalshi series ticker.
+            event_ticker: Filter by Kalshi event ticker.
+            live_only: When ``True``, restrict to live games.
+            sort: One of ``"volume"`` (default), ``"closing_soon"``, ``"newest"``.
+        """
+        if sort is not None:
+            _validate_enum("sort", sort, _VALID_SPORTS_SORTS)
+        raw = self._get(
+            "/api/v1/sports/markets",
+            params={
+                "page": page,
+                "limit": limit,
+                "category": category,
+                "search": search,
+                "seriesTicker": series_ticker,
+                "eventTicker": event_ticker,
+                "liveOnly": live_only,
+                "sort": sort,
+            },
+        )
+        return PaginatedResponse(
+            data=list(raw.get("data", [])),
+            **_parse_pagination(raw),
+        )
+
+    def list_sports_events(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        category: str | None = None,
+        series_ticker: str | None = None,
+        status: str | None = None,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List sports events with optional filters.
+
+        Args:
+            page: 1-based page index (default ``1``).
+            limit: Page size (default ``10``).
+            category: Filter by category slug.
+            series_ticker: Filter by Kalshi series ticker.
+            status: One of ``"SCHEDULED"``, ``"PREGAME"``, ``"LIVE"``,
+                ``"HALFTIME"``, ``"FINAL"``.
+        """
+        if status is not None:
+            _validate_enum("status", status, _VALID_SPORTS_EVENT_STATUSES)
+        raw = self._get(
+            "/api/v1/sports/events",
+            params={
+                "page": page,
+                "limit": limit,
+                "category": category,
+                "seriesTicker": series_ticker,
+                "status": status,
+            },
+        )
+        return PaginatedResponse(
+            data=list(raw.get("data", [])),
+            **_parse_pagination(raw),
+        )
+
+    def get_sports_event(self, event_ticker: str) -> dict[str, Any]:
+        """Fetch a single sports event with its associated markets.
+
+        Args:
+            event_ticker: Kalshi event ticker (URL-encoded).
+
+        Returns:
+            ``{"event": {...}, "markets": [...]}`` mirroring the controller.
+        """
+        return self._get(f"/api/v1/sports/events/{_encode_path(event_ticker)}")
+
+    def list_sports_milestones(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        event_ticker: str | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """List in-game milestones (cursor-paginated).
+
+        Args:
+            page: 1-based page index (default ``1``).
+            limit: Page size (default ``10``).
+            event_ticker: Optional event ticker filter.
+            status: Optional status filter (free-form per upstream Kalshi feed).
+
+        Returns:
+            ``{"milestones": [...], "cursor": str | None}``.
+        """
+        return self._get(
+            "/api/v1/sports/milestones",
+            params={
+                "page": page,
+                "limit": limit,
+                "eventTicker": event_ticker,
+                "status": status,
+            },
+        )
+
+    def get_sports_live_data(self, milestone_id: str) -> dict[str, Any]:
+        """Fetch live data attached to a specific milestone.
+
+        Args:
+            milestone_id: Milestone identifier (URL-encoded).
+
+        Returns:
+            ``{"liveData": object | None}``.
+        """
+        return self._get(
+            f"/api/v1/sports/live-data/{_encode_path(milestone_id)}",
+        )
+
+    def list_sports_combos(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        series_ticker: str | None = None,
+    ) -> dict[str, Any]:
+        """List combo collections (cursor-paginated).
+
+        Args:
+            page: 1-based page index (default ``1``).
+            limit: Page size (default ``10``).
+            series_ticker: Optional series ticker filter.
+
+        Returns:
+            ``{"collections": [...], "cursor": str | None}``.
+        """
+        return self._get(
+            "/api/v1/sports/combos",
+            params={
+                "page": page,
+                "limit": limit,
+                "seriesTicker": series_ticker,
+            },
+        )
+
+    def get_sports_combo_collection(self, collection_ticker: str) -> dict[str, Any]:
+        """Fetch a combo collection by ticker.
+
+        Note:
+            The upstream controller currently ignores ``collectionTicker`` and
+            delegates to ``listComboCollections({page:1, limit:1})``. The SDK
+            wraps the endpoint as-is; tracked for follow-up under
+            `POLA-1841 </POLA/issues/POLA-1841>`_.
+        """
+        return self._get(
+            f"/api/v1/sports/combos/{_encode_path(collection_ticker)}",
+        )
+
+    def lookup_sports_combo(
+        self,
+        collection_ticker: str,
+        selected_markets: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Resolve a combo selection to a single ``(eventTicker, marketTicker)``.
+
+        Args:
+            collection_ticker: Collection ticker the combo belongs to.
+            selected_markets: List of ``{"marketTicker", "eventTicker", "side"}``
+                entries where ``side`` is ``"yes"`` or ``"no"``. Passed through
+                to the server unchanged (server enforces shape and side enum).
+
+        Returns:
+            ``{"eventTicker", "marketTicker"}`` on a hit, or ``None`` if the
+            combo cannot be resolved.
+        """
+        result = self._post(
+            "/api/v1/sports/combos/lookup",
+            json={
+                "collectionTicker": collection_ticker,
+                "selectedMarkets": selected_markets,
+            },
+        )
+        return result if isinstance(result, dict) else None
+
     # -- Lifecycle --
 
     def close(self) -> None:
@@ -4943,6 +5159,145 @@ class AsyncPolyforgeClient:
             VenuePreferences,
             await self._patch("/api/v1/users/me/venue-preferences", json=body),
         )
+
+    # -- Sports Markets --
+
+    async def list_sports_categories(self) -> list[dict[str, Any]]:
+        """List sports market categories. See sync version for details."""
+        data = await self._get("/api/v1/sports/categories")
+        return list(data) if isinstance(data, list) else []
+
+    async def list_sports_markets(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        category: str | None = None,
+        search: str | None = None,
+        series_ticker: str | None = None,
+        event_ticker: str | None = None,
+        live_only: bool | None = None,
+        sort: str | None = None,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List sports markets with optional filters. See sync version."""
+        if sort is not None:
+            _validate_enum("sort", sort, _VALID_SPORTS_SORTS)
+        raw = await self._get(
+            "/api/v1/sports/markets",
+            params={
+                "page": page,
+                "limit": limit,
+                "category": category,
+                "search": search,
+                "seriesTicker": series_ticker,
+                "eventTicker": event_ticker,
+                "liveOnly": live_only,
+                "sort": sort,
+            },
+        )
+        return PaginatedResponse(
+            data=list(raw.get("data", [])),
+            **_parse_pagination(raw),
+        )
+
+    async def list_sports_events(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        category: str | None = None,
+        series_ticker: str | None = None,
+        status: str | None = None,
+    ) -> PaginatedResponse[dict[str, Any]]:
+        """List sports events with optional filters. See sync version."""
+        if status is not None:
+            _validate_enum("status", status, _VALID_SPORTS_EVENT_STATUSES)
+        raw = await self._get(
+            "/api/v1/sports/events",
+            params={
+                "page": page,
+                "limit": limit,
+                "category": category,
+                "seriesTicker": series_ticker,
+                "status": status,
+            },
+        )
+        return PaginatedResponse(
+            data=list(raw.get("data", [])),
+            **_parse_pagination(raw),
+        )
+
+    async def get_sports_event(self, event_ticker: str) -> dict[str, Any]:
+        """Fetch a single sports event with markets. See sync version."""
+        return await self._get(
+            f"/api/v1/sports/events/{_encode_path(event_ticker)}",
+        )
+
+    async def list_sports_milestones(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        event_ticker: str | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """List in-game milestones. See sync version."""
+        return await self._get(
+            "/api/v1/sports/milestones",
+            params={
+                "page": page,
+                "limit": limit,
+                "eventTicker": event_ticker,
+                "status": status,
+            },
+        )
+
+    async def get_sports_live_data(self, milestone_id: str) -> dict[str, Any]:
+        """Fetch live data for a milestone. See sync version."""
+        return await self._get(
+            f"/api/v1/sports/live-data/{_encode_path(milestone_id)}",
+        )
+
+    async def list_sports_combos(
+        self,
+        *,
+        page: int = 1,
+        limit: int = 10,
+        series_ticker: str | None = None,
+    ) -> dict[str, Any]:
+        """List combo collections. See sync version."""
+        return await self._get(
+            "/api/v1/sports/combos",
+            params={
+                "page": page,
+                "limit": limit,
+                "seriesTicker": series_ticker,
+            },
+        )
+
+    async def get_sports_combo_collection(
+        self, collection_ticker: str
+    ) -> dict[str, Any]:
+        """Fetch a combo collection by ticker. See sync version for the
+        upstream-controller caveat."""
+        return await self._get(
+            f"/api/v1/sports/combos/{_encode_path(collection_ticker)}",
+        )
+
+    async def lookup_sports_combo(
+        self,
+        collection_ticker: str,
+        selected_markets: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Resolve a combo selection. See sync version for the payload shape."""
+        result = await self._post(
+            "/api/v1/sports/combos/lookup",
+            json={
+                "collectionTicker": collection_ticker,
+                "selectedMarkets": selected_markets,
+            },
+        )
+        return result if isinstance(result, dict) else None
 
     # -- Lifecycle --
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5800,3 +5800,343 @@ class TestTradingCopyNumericValidation:
             await client.close()
 
         asyncio.run(_run())
+
+
+# ── POLA-1847: 9 sports markets endpoints ────────────────────────────────────
+
+
+class TestSportsEndpointsPresence:
+    """Surface check: all 9 sports methods exist on both clients (POLA-1847)."""
+
+    METHODS = (
+        "list_sports_categories",
+        "list_sports_markets",
+        "list_sports_events",
+        "get_sports_event",
+        "list_sports_milestones",
+        "get_sports_live_data",
+        "list_sports_combos",
+        "get_sports_combo_collection",
+        "lookup_sports_combo",
+    )
+
+    def test_all_methods_present_on_sync_client(self):
+        for name in self.METHODS:
+            assert callable(getattr(PolyforgeClient, name, None)), name
+
+    def test_all_methods_present_on_async_client(self):
+        for name in self.METHODS:
+            assert callable(getattr(AsyncPolyforgeClient, name, None)), name
+
+
+class TestSportsEndpointsPaths:
+    """Verify each sports method targets the correct controller path."""
+
+    def test_list_sports_categories_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_categories)
+        assert '"/api/v1/sports/categories"' in src
+
+    def test_list_sports_markets_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_markets)
+        assert '"/api/v1/sports/markets"' in src
+
+    def test_list_sports_events_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_events)
+        assert '"/api/v1/sports/events"' in src
+
+    def test_get_sports_event_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.get_sports_event)
+        assert "/api/v1/sports/events/" in src
+
+    def test_list_sports_milestones_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_milestones)
+        assert '"/api/v1/sports/milestones"' in src
+
+    def test_get_sports_live_data_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.get_sports_live_data)
+        assert "/api/v1/sports/live-data/" in src
+
+    def test_list_sports_combos_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_combos)
+        assert '"/api/v1/sports/combos"' in src
+
+    def test_get_sports_combo_collection_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.get_sports_combo_collection)
+        assert "/api/v1/sports/combos/" in src
+
+    def test_lookup_sports_combo_path(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.lookup_sports_combo)
+        assert '"/api/v1/sports/combos/lookup"' in src
+
+
+class TestSportsEndpointsParams:
+    """Verify each sports method exposes the expected keyword parameters."""
+
+    def test_list_sports_markets_signature(self):
+        import inspect
+        params = set(inspect.signature(PolyforgeClient.list_sports_markets).parameters)
+        for required in (
+            "page", "limit", "category", "search", "series_ticker",
+            "event_ticker", "live_only", "sort",
+        ):
+            assert required in params, required
+
+    def test_list_sports_markets_passes_camel_case_query_keys(self):
+        import inspect
+        src = inspect.getsource(PolyforgeClient.list_sports_markets)
+        # Server expects camelCase query keys, not snake_case.
+        for key in ('"seriesTicker"', '"eventTicker"', '"liveOnly"', '"sort"'):
+            assert key in src, key
+
+    def test_list_sports_events_signature(self):
+        import inspect
+        params = set(inspect.signature(PolyforgeClient.list_sports_events).parameters)
+        for required in ("page", "limit", "category", "series_ticker", "status"):
+            assert required in params, required
+
+    def test_list_sports_milestones_signature(self):
+        import inspect
+        params = set(inspect.signature(PolyforgeClient.list_sports_milestones).parameters)
+        for required in ("page", "limit", "event_ticker", "status"):
+            assert required in params, required
+
+    def test_list_sports_combos_signature(self):
+        import inspect
+        params = set(inspect.signature(PolyforgeClient.list_sports_combos).parameters)
+        for required in ("page", "limit", "series_ticker"):
+            assert required in params, required
+
+    def test_async_list_sports_markets_signature(self):
+        import inspect
+        params = set(inspect.signature(AsyncPolyforgeClient.list_sports_markets).parameters)
+        assert {"sort", "live_only", "series_ticker", "event_ticker"} <= params
+
+
+class TestSportsEnumValidation:
+    """Reject invalid enum values without making a network call."""
+
+    def test_invalid_sort_rejected(self):
+        client = PolyforgeClient(api_key="test")
+        try:
+            with pytest.raises(ValueError, match="sort"):
+                client.list_sports_markets(sort="trending")
+        finally:
+            client.close()
+
+    def test_invalid_event_status_rejected(self):
+        client = PolyforgeClient(api_key="test")
+        try:
+            with pytest.raises(ValueError, match="status"):
+                client.list_sports_events(status="POSTGAME")
+        finally:
+            client.close()
+
+    def test_async_invalid_sort_rejected(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            try:
+                with pytest.raises(ValueError, match="sort"):
+                    await client.list_sports_markets(sort="garbage")
+            finally:
+                await client.close()
+
+        asyncio.run(_run())
+
+
+class TestSportsEndpointRoundtrips:
+    """Stub the HTTP layer with httpx.MockTransport and exercise each method."""
+
+    @staticmethod
+    def _client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    def test_list_sports_categories_returns_array(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/v1/sports/categories"
+            return httpx.Response(200, json=[
+                {"category": "nba", "label": "NBA",
+                 "seriesTickers": ["KXNBAGAME"], "marketCount": 12}
+            ])
+        client = self._client_with(handler)
+        try:
+            cats = client.list_sports_categories()
+            assert isinstance(cats, list)
+            assert cats[0]["category"] == "nba"
+            assert cats[0]["marketCount"] == 12
+        finally:
+            client.close()
+
+    def test_list_sports_markets_sends_params_and_parses_pagination(self):
+        captured = {}
+
+        def handler(request):
+            captured["url"] = request.url
+            return httpx.Response(200, json={
+                "data": [{"ticker": "KXNBAGAME-1"}],
+                "total": 1, "page": 1, "limit": 10,
+                "totalPages": 1, "hasNext": False,
+            })
+
+        client = self._client_with(handler)
+        try:
+            res = client.list_sports_markets(
+                category="nba",
+                series_ticker="KXNBAGAME",
+                live_only=True,
+                sort="closing_soon",
+                page=2,
+                limit=5,
+            )
+            qp = dict(captured["url"].params)
+            assert qp["category"] == "nba"
+            assert qp["seriesTicker"] == "KXNBAGAME"
+            # httpx lowercases booleans → "true"; the controller DTO maps "true" → True.
+            assert qp["liveOnly"] == "true"
+            assert qp["sort"] == "closing_soon"
+            assert qp["page"] == "2"
+            assert qp["limit"] == "5"
+            assert "search" not in qp  # None values stripped
+            assert isinstance(res, PaginatedResponse)
+            assert res.total == 1
+            assert res.page == 1
+            assert res.data[0]["ticker"] == "KXNBAGAME-1"
+        finally:
+            client.close()
+
+    def test_list_sports_events_sends_params(self):
+        captured = {}
+
+        def handler(request):
+            captured["url"] = request.url
+            return httpx.Response(200, json={
+                "data": [], "total": 0, "page": 1, "limit": 10, "totalPages": 0,
+            })
+        client = self._client_with(handler)
+        try:
+            client.list_sports_events(status="LIVE", series_ticker="KXNBAGAME")
+            qp = dict(captured["url"].params)
+            assert qp["status"] == "LIVE"
+            assert qp["seriesTicker"] == "KXNBAGAME"
+        finally:
+            client.close()
+
+    def test_get_sports_event_url_encodes_ticker(self):
+        captured = {}
+
+        def handler(request):
+            # httpx.URL.path is decoded; raw_path keeps the percent-encoding.
+            captured["raw_path"] = request.url.raw_path
+            return httpx.Response(200, json={"event": {"ticker": "T/1"}, "markets": []})
+        client = self._client_with(handler)
+        try:
+            res = client.get_sports_event("T/1")
+            assert captured["raw_path"] == b"/api/v1/sports/events/T%2F1"
+            assert res["event"]["ticker"] == "T/1"
+            assert res["markets"] == []
+        finally:
+            client.close()
+
+    def test_list_sports_milestones_returns_cursor_dict(self):
+        def handler(request):
+            assert request.url.path == "/api/v1/sports/milestones"
+            return httpx.Response(200, json={
+                "milestones": [{"id": "m1"}],
+                "cursor": "next-page-token",
+            })
+        client = self._client_with(handler)
+        try:
+            res = client.list_sports_milestones(event_ticker="EVT", limit=20)
+            assert res["cursor"] == "next-page-token"
+            assert res["milestones"][0]["id"] == "m1"
+        finally:
+            client.close()
+
+    def test_get_sports_live_data_returns_payload(self):
+        def handler(request):
+            assert request.url.path == "/api/v1/sports/live-data/abc"
+            return httpx.Response(200, json={"liveData": {"score": "10-7"}})
+        client = self._client_with(handler)
+        try:
+            assert client.get_sports_live_data("abc") == {"liveData": {"score": "10-7"}}
+        finally:
+            client.close()
+
+    def test_list_sports_combos_sends_series_ticker(self):
+        captured = {}
+
+        def handler(request):
+            captured["url"] = request.url
+            return httpx.Response(200, json={"collections": [], "cursor": None})
+        client = self._client_with(handler)
+        try:
+            client.list_sports_combos(series_ticker="KXNBAGAME")
+            assert captured["url"].params["seriesTicker"] == "KXNBAGAME"
+        finally:
+            client.close()
+
+    def test_get_sports_combo_collection_url_encodes_ticker(self):
+        captured = {}
+
+        def handler(request):
+            captured["raw_path"] = request.url.raw_path
+            return httpx.Response(200, json={"collections": [], "cursor": None})
+        client = self._client_with(handler)
+        try:
+            client.get_sports_combo_collection("KX/COMBO 1")
+            assert captured["raw_path"] == b"/api/v1/sports/combos/KX%2FCOMBO%201"
+        finally:
+            client.close()
+
+    def test_lookup_sports_combo_posts_payload(self):
+        captured = {}
+
+        def handler(request):
+            captured["method"] = request.method
+            captured["path"] = request.url.path
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "eventTicker": "EVT", "marketTicker": "MKT",
+            })
+        client = self._client_with(handler)
+        try:
+            res = client.lookup_sports_combo(
+                "COL",
+                [{"marketTicker": "M1", "eventTicker": "E1", "side": "yes"}],
+            )
+            assert captured["method"] == "POST"
+            assert captured["path"] == "/api/v1/sports/combos/lookup"
+            assert captured["body"]["collectionTicker"] == "COL"
+            assert captured["body"]["selectedMarkets"][0]["side"] == "yes"
+            assert res == {"eventTicker": "EVT", "marketTicker": "MKT"}
+        finally:
+            client.close()
+
+    def test_lookup_sports_combo_returns_none_on_null_body(self):
+        # Server returns JSON `null` when no match — SDK must surface as None.
+        def handler(request):
+            return httpx.Response(200, content=b"null", headers={"content-type": "application/json"})
+        client = self._client_with(handler)
+        try:
+            res = client.lookup_sports_combo("COL", [])
+            assert res is None
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary

Adds the Python SDK side of [POLA-1841](/POLA/issues/POLA-1841) — wrappers for the nine `/api/v1/sports/*` controller endpoints on both `PolyforgeClient` (sync) and `AsyncPolyforgeClient` (async).

| Method | Endpoint |
|---|---|
| `list_sports_categories()` | `GET /api/v1/sports/categories` |
| `list_sports_markets(...)` | `GET /api/v1/sports/markets` |
| `list_sports_events(...)` | `GET /api/v1/sports/events` |
| `get_sports_event(event_ticker)` | `GET /api/v1/sports/events/:eventTicker` |
| `list_sports_milestones(...)` | `GET /api/v1/sports/milestones` |
| `get_sports_live_data(milestone_id)` | `GET /api/v1/sports/live-data/:milestoneId` |
| `list_sports_combos(...)` | `GET /api/v1/sports/combos` |
| `get_sports_combo_collection(collection_ticker)` | `GET /api/v1/sports/combos/:collectionTicker` |
| `lookup_sports_combo(...)` | `POST /api/v1/sports/combos/lookup` |

## Design notes

- **Permissive types** — controller returns `Record<string, unknown>` / `unknown[]`; the SDK mirrors that with `dict[str, Any]` / `PaginatedResponse[dict[str, Any]]` per the parent plan. No dataclass invention.
- **Enum validation** — `sort` (`{"volume", "closing_soon", "newest"}`) and event `status` (`{"SCHEDULED", "PREGAME", "LIVE", "HALFTIME", "FINAL"}`) validated client-side via existing `_validate_enum` helper.
- **Path-traversal hardening** — `event_ticker`, `milestone_id`, `collection_ticker` URL-encoded via existing `_encode_path` (CWE-22).
- **Camel-case query keys** — `seriesTicker`, `eventTicker`, `liveOnly` sent in the casing the controller DTOs expect.
- **Combo-by-ticker quirk** — server currently ignores the ticker path param and delegates to `listComboCollections({page:1, limit:1})`. SDK wraps the broken endpoint as-is; follow-up tracked under [POLA-1841](/POLA/issues/POLA-1841).
- No new top-level dependencies.

## Tests

30 new tests across 5 classes (`TestSportsEndpointsPresence`, `TestSportsEndpointsPaths`, `TestSportsEndpointsParams`, `TestSportsEnumValidation`, `TestSportsEndpointRoundtrips`) — introspection + `httpx.MockTransport` roundtrips that verify URLs, query keys, raw path encoding, request bodies, and pagination parsing.

`pytest tests/`: **771/771 pass** (741 pre-existing + 30 new).

## Test plan

- [x] `uv run --frozen pytest tests/test_client.py` → 771 pass
- [x] All 9 methods present on both sync and async clients (`dir()` parity check passes)
- [x] Enum validation rejects bad `sort` / `status` without making a network call
- [x] Roundtrip tests verify camelCase keys, URL encoding, POST body shape, and `null` response → `None` mapping
- [x] CHANGELOG + README updated

Closes POLA-1847. Parent: [POLA-1841](/POLA/issues/POLA-1841).