### PR TITLE
fix: hide admin-only match mutations

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1856,28 +1856,6 @@ class PolyforgeClient:
         data = self._get(f"/api/v1/arbitrage/matches/market/{_encode_path(market_id)}")
         return [_parse(MarketMatch, o) for o in data]
 
-    def create_match(self, *, polymarket_id: str, kalshi_id: str) -> MarketMatch:
-        """Manually match two markets across venues."""
-        data = self._post("/api/v1/arbitrage/matches", json={
-            "polymarketId": polymarket_id,
-            "kalshiId": kalshi_id,
-        })
-        return _parse(MarketMatch, data)
-
-    def verify_match(self, match_id: str) -> MarketMatch:
-        """Verify/confirm an auto-matched market pair."""
-        data = self._post(f"/api/v1/arbitrage/matches/{_encode_path(match_id)}/verify")
-        return _parse(MarketMatch, data)
-
-    def delete_match(self, match_id: str) -> None:
-        """Remove a market match (unmatch)."""
-        self._delete(f"/api/v1/arbitrage/matches/{_encode_path(match_id)}")
-
-    def sync_matches(self) -> MatchSyncResult:
-        """Trigger a manual TF-IDF matching pass."""
-        data = self._post("/api/v1/arbitrage/matches/sync")
-        return _parse(MatchSyncResult, data)
-
     # -- Cross-Venue Arb Execution / Positions / Risk --
     #
     # SAFETY: ``execute_arb`` and ``close_arb_position`` place real orders on
@@ -5108,28 +5086,6 @@ class AsyncPolyforgeClient:
         """Get all matches for a specific market (either venue)."""
         data = await self._get(f"/api/v1/arbitrage/matches/market/{_encode_path(market_id)}")
         return [_parse(MarketMatch, o) for o in data]
-
-    async def create_match(self, *, polymarket_id: str, kalshi_id: str) -> MarketMatch:
-        """Manually match two markets across venues."""
-        data = await self._post("/api/v1/arbitrage/matches", json={
-            "polymarketId": polymarket_id,
-            "kalshiId": kalshi_id,
-        })
-        return _parse(MarketMatch, data)
-
-    async def verify_match(self, match_id: str) -> MarketMatch:
-        """Verify/confirm an auto-matched market pair."""
-        data = await self._post(f"/api/v1/arbitrage/matches/{_encode_path(match_id)}/verify")
-        return _parse(MarketMatch, data)
-
-    async def delete_match(self, match_id: str) -> None:
-        """Remove a market match (unmatch)."""
-        await self._delete(f"/api/v1/arbitrage/matches/{_encode_path(match_id)}")
-
-    async def sync_matches(self) -> MatchSyncResult:
-        """Trigger a manual TF-IDF matching pass."""
-        data = await self._post("/api/v1/arbitrage/matches/sync")
-        return _parse(MatchSyncResult, data)
 
     # -- Cross-Venue Arb Execution / Positions / Risk --
     #

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4552,54 +4552,17 @@ class TestCrossVenueArbitrage:
         client._get.assert_called_once_with("/api/v1/arbitrage/matches/market/p1")
         client.close()
 
-    def test_sync_create_match(self):
-        from unittest.mock import MagicMock
-        client = PolyforgeClient(api_key="test-key")
-        client._post = MagicMock(return_value={
-            "id": "m1", "polymarketId": "p1", "kalshiId": "k1",
-            "confidence": 1.0, "matchMethod": "manual",
-            "verified": False, "createdAt": "2026-04-24T00:00:00Z",
-            "updatedAt": "2026-04-24T00:00:00Z",
-        })
-        result = client.create_match(polymarket_id="p1", kalshi_id="k1")
-        assert result.id == "m1"
-        assert result.match_method == "manual"
-        client._post.assert_called_once_with(
-            "/api/v1/arbitrage/matches",
-            json={"polymarketId": "p1", "kalshiId": "k1"},
-        )
-        client.close()
+    def test_admin_only_match_mutations_are_not_public_client_methods(self):
+        admin_only_methods = [
+            "create_match",
+            "verify_match",
+            "delete_match",
+            "sync_matches",
+        ]
 
-    def test_sync_verify_match(self):
-        from unittest.mock import MagicMock
-        client = PolyforgeClient(api_key="test-key")
-        client._post = MagicMock(return_value={
-            "id": "m1", "polymarketId": "p1", "kalshiId": "k1",
-            "confidence": 0.9, "matchMethod": "auto_tfidf",
-            "verified": True, "createdAt": "2026-04-24T00:00:00Z",
-            "updatedAt": "2026-04-24T00:00:00Z",
-        })
-        result = client.verify_match("m1")
-        assert result.verified is True
-        client._post.assert_called_once_with("/api/v1/arbitrage/matches/m1/verify")
-        client.close()
-
-    def test_sync_delete_match(self):
-        from unittest.mock import MagicMock
-        client = PolyforgeClient(api_key="test-key")
-        client._delete = MagicMock(return_value=None)
-        client.delete_match("m1")
-        client._delete.assert_called_once_with("/api/v1/arbitrage/matches/m1")
-        client.close()
-
-    def test_sync_sync_matches(self):
-        from unittest.mock import MagicMock
-        client = PolyforgeClient(api_key="test-key")
-        client._post = MagicMock(return_value={"matched": 5})
-        result = client.sync_matches()
-        assert result.matched == 5
-        client._post.assert_called_once_with("/api/v1/arbitrage/matches/sync")
-        client.close()
+        for method_name in admin_only_methods:
+            assert not hasattr(PolyforgeClient, method_name)
+            assert not hasattr(AsyncPolyforgeClient, method_name)
 
     def test_async_cross_venue_methods_exist(self):
         import inspect
@@ -4615,10 +4578,6 @@ class TestCrossVenueArbitrage:
             "delete_arbitrage_alert",
             "get_cross_venue_comparison",
             "get_matches_by_market",
-            "create_match",
-            "verify_match",
-            "delete_match",
-            "sync_matches",
         ]
         for method_name in methods:
             assert hasattr(AsyncPolyforgeClient, method_name), f"AsyncPolyforgeClient missing {method_name}"


### PR DESCRIPTION
## Summary
- Remove public sync/async client methods for admin-only arbitrage match mutations: create_match, verify_match, delete_match, sync_matches
- Replace positive mutation endpoint tests with a public-surface regression that asserts those methods are absent
- Keep public read-only arbitrage match endpoints intact

## Verification
- GitNexus impact: method-level LOW risk; direct callers limited to obsolete tests, no affected execution flows
- GitNexus detect_changes: ran on staged diff; reported 2 files with CRITICAL graph risk due monolithic exported client.py fan-out, reviewed staged diff as scoped to the four methods and tests
- PYTHONPATH=src pytest tests/test_client.py::TestCrossVenueArbitrage -q
- PYTHONPATH=src pytest tests/test_client.py -q (890 passed)
- git diff --staged --check

Refs F4CTE/PolyForge#1234
Refs POLA-2554