### PR TITLE
fix: parse Polymarket portfolio response wrappers

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2638,13 +2638,13 @@ class PolyforgeClient:
     def get_polymarket_portfolio(self) -> list[PolymarketPortfolioEntry]:
         """Fetch the Polymarket-native portfolio positions for the connected wallet."""
         data = self._get("/api/v1/portfolio/polymarket/portfolio")
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketPortfolioEntry, e) for e in items]
 
     def get_polymarket_earnings(self) -> list[PolymarketEarningsEntry]:
         """Fetch daily earnings from the Polymarket rewards programme."""
         data = self._get("/api/v1/portfolio/polymarket/earnings")
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketEarningsEntry, e) for e in items]
 
     def get_polymarket_activity(self, *, activity_type: str | None = None) -> list[PolymarketActivity]:
@@ -2657,7 +2657,7 @@ class PolyforgeClient:
             "/api/v1/portfolio/polymarket/activity",
             params=_strip_none({"type": activity_type}),
         )
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("activities", data.get("data", []))
         return [_parse(PolymarketActivity, a) for a in items]
 
     def list_copy_configs(self) -> list[CopyConfig]:
@@ -5718,13 +5718,13 @@ class AsyncPolyforgeClient:
     async def get_polymarket_portfolio(self) -> list[PolymarketPortfolioEntry]:
         """Fetch the Polymarket-native portfolio positions for the connected wallet."""
         data = await self._get("/api/v1/portfolio/polymarket/portfolio")
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketPortfolioEntry, e) for e in items]
 
     async def get_polymarket_earnings(self) -> list[PolymarketEarningsEntry]:
         """Fetch daily earnings from the Polymarket rewards programme."""
         data = await self._get("/api/v1/portfolio/polymarket/earnings")
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketEarningsEntry, e) for e in items]
 
     async def get_polymarket_activity(self, *, activity_type: str | None = None) -> list[PolymarketActivity]:
@@ -5737,7 +5737,7 @@ class AsyncPolyforgeClient:
             "/api/v1/portfolio/polymarket/activity",
             params=_strip_none({"type": activity_type}),
         )
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = data if isinstance(data, list) else data.get("activities", data.get("data", []))
         return [_parse(PolymarketActivity, a) for a in items]
 
     async def list_copy_configs(self) -> list[CopyConfig]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3953,6 +3953,28 @@ class TestScoresBadgeEndpoints:
 class TestPolymarketPortfolioEndpoints:
     """Tests for the 3 new Polymarket-native portfolio endpoints (POLA-476)."""
 
+    @staticmethod
+    def _client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    @staticmethod
+    def _async_client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = AsyncPolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.AsyncClient(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
     def test_get_polymarket_portfolio_exists_sync(self):
         assert callable(getattr(PolyforgeClient, "get_polymarket_portfolio", None))
 
@@ -3991,6 +4013,104 @@ class TestPolymarketPortfolioEndpoints:
         sig = inspect.signature(PolyforgeClient.get_polymarket_activity)
         params = set(sig.parameters.keys())
         assert "activity_type" in params
+
+    def test_get_polymarket_portfolio_reads_entries_wrapper(self):
+        def handler(request):
+            assert request.url.path == "/api/v1/portfolio/polymarket/portfolio"
+            return httpx.Response(200, json={
+                "entries": [
+                    {"asset": "BTC", "size": "10", "avgPrice": "0.50"},
+                ],
+            })
+
+        client = self._client_with(handler)
+        try:
+            entries = client.get_polymarket_portfolio()
+            assert len(entries) == 1
+            assert entries[0].asset == "BTC"
+            assert entries[0].size == "10"
+            assert entries[0].avg_price == "0.50"
+        finally:
+            client.close()
+
+    def test_get_polymarket_earnings_reads_entries_wrapper(self):
+        def handler(request):
+            assert request.url.path == "/api/v1/portfolio/polymarket/earnings"
+            return httpx.Response(200, json={
+                "entries": [
+                    {
+                        "date": "2026-01-01",
+                        "earnings": "50.0",
+                        "volume": "1000.0",
+                        "winRate": "0.6",
+                    },
+                ],
+            })
+
+        client = self._client_with(handler)
+        try:
+            entries = client.get_polymarket_earnings()
+            assert len(entries) == 1
+            assert entries[0].date == "2026-01-01"
+            assert entries[0].earnings == "50.0"
+            assert entries[0].win_rate == "0.6"
+        finally:
+            client.close()
+
+    def test_get_polymarket_activity_reads_activities_wrapper_and_filter(self):
+        captured = {}
+
+        def handler(request):
+            captured["params"] = dict(request.url.params)
+            assert request.url.path == "/api/v1/portfolio/polymarket/activity"
+            return httpx.Response(200, json={
+                "activities": [
+                    {"id": "act-1", "type": "trade", "amount": "12.5"},
+                ],
+            })
+
+        client = self._client_with(handler)
+        try:
+            activities = client.get_polymarket_activity(activity_type="trade")
+            assert captured["params"] == {"type": "trade"}
+            assert len(activities) == 1
+            assert activities[0].id == "act-1"
+            assert activities[0].type == "trade"
+            assert activities[0].amount == "12.5"
+        finally:
+            client.close()
+
+    def test_async_polymarket_wrappers_match_sync_fields(self):
+        import asyncio
+
+        def handler(request):
+            if request.url.path.endswith("/portfolio"):
+                return httpx.Response(200, json={
+                    "entries": [{"asset": "ETH", "size": "2"}],
+                })
+            if request.url.path.endswith("/earnings"):
+                return httpx.Response(200, json={
+                    "entries": [{"date": "2026-01-02", "earnings": "5"}],
+                })
+            if request.url.path.endswith("/activity"):
+                return httpx.Response(200, json={
+                    "activities": [{"id": "act-2", "type": "deposit"}],
+                })
+            return httpx.Response(404)
+
+        async def _run():
+            client = self._async_client_with(handler)
+            try:
+                portfolio = await client.get_polymarket_portfolio()
+                earnings = await client.get_polymarket_earnings()
+                activity = await client.get_polymarket_activity()
+                assert portfolio[0].asset == "ETH"
+                assert earnings[0].date == "2026-01-02"
+                assert activity[0].id == "act-2"
+            finally:
+                await client.close()
+
+        asyncio.run(_run())
 
 
 class TestNewModels:


### PR DESCRIPTION
## Summary
- Parse Polymarket portfolio and earnings responses from the `entries` wrapper.
- Parse Polymarket activity responses from the `activities` wrapper.
- Add sync and async regression coverage for the wrapper shapes while retaining legacy `data` fallback.

## Test Plan
- `PYTHONPATH=src python3 -m pytest tests/test_client.py::TestPolymarketPortfolioEndpoints -q`
- `timeout 300 env PYTHONPATH=src python3 -m pytest tests/test_client.py -q`
- `git diff --check`

Closes #214
