### PR TITLE
fix(sdk-python): accept FAK order type

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -407,7 +407,7 @@ def _validate_enum(name: str, value: str, allowed: frozenset[str]) -> None:
 _VALID_MODES = frozenset({"live", "paper"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
-_VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "POST_ONLY"})
+_VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "FAK", "POST_ONLY"})
 _VALID_SPORTS_SORTS = frozenset({"volume", "closing_soon", "newest"})
 _VALID_SPORTS_EVENT_STATUSES = frozenset(
     {"SCHEDULED", "PREGAME", "LIVE", "HALFTIME", "FINAL"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -829,8 +829,12 @@ class TestEnumValidation:
 
     def test_valid_order_types_match_platform_dto(self):
         """SDK order types must include all values from platform's OrderTypeDto."""
-        platform_order_types = {"GTC", "GTD", "FOK", "POST_ONLY"}
+        platform_order_types = {"GTC", "GTD", "FOK", "FAK", "POST_ONLY"}
         assert _VALID_ORDER_TYPES == platform_order_types
+
+    def test_place_order_accepts_fak(self):
+        """FAK is a valid platform order type — SDK must not reject it."""
+        _validate_enum("order_type", "FAK", _VALID_ORDER_TYPES)
 
     def test_place_order_accepts_post_only(self):
         """POST_ONLY is a valid platform order type — SDK must not reject it."""


### PR DESCRIPTION
## Summary
- Add FAK to the SDK order type allow-list used by place_order, batch orders, and fee preview validation.
- Add regression coverage matching the platform OrderTypeDto and asserting FAK validation is accepted.

## Test Plan
- PYTHONPATH=src python3 -m pytest tests/test_client.py -q
- PYTHONPATH=src python3 -m compileall -q src tests
- git diff --check
- npx gitnexus detect-changes --repo /home/f4cte/polyforge-sdk-python/.paperclip/worktrees/POLA-2753-polyforge-sdk-python-211-compat-sdk-python-place_order-rejects-fak-order-type-accepted-by-platform-_valid_orde

Closes #211