### PR TITLE
fix: add POLYMARKET_US to Venue Literal type

### DIFF
--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -586,7 +586,7 @@ ArbPositionStatus = Literal[
 ]
 
 # Venue identifiers mirror the server-side ``Venue`` enum.
-Venue = Literal["POLYMARKET", "KALSHI"]
+Venue = Literal["POLYMARKET", "KALSHI", "POLYMARKET_US"]
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7179,6 +7179,8 @@ class TestArbValidators_POLA_1873:
         from polyforge import ArbPositionStatus, Venue
         assert "PENDING" in ArbPositionStatus.__args__
         assert "POLYMARKET" in Venue.__args__
+        assert "KALSHI" in Venue.__args__
+        assert "POLYMARKET_US" in Venue.__args__
 
     def test_limit_below_one_rejected(self):
         from polyforge.client import _validate_arb_limit


### PR DESCRIPTION
## Summary
- Adds `POLYMARKET_US` to the `Venue` Literal type in `models.py`
- Achieves feature parity with the TS SDK's `KnownVenueId` and server-side Prisma `Venue` enum
- Updates test to assert all three venue values

## Related
- Closes #228
- POLA-3459

## Test Plan
- [x] All 930 tests pass
- [x] `test_arb_literal_types_exported_from_package` asserts POLYMARKET, KALSHI, and POLYMARKET_US