### PR TITLE
feat(sdk-python): add get_my_preferences/update_my_preferences and UserPreferences alias (POLA-4163)

### DIFF
--- a/src/polyforge/__init__.py
+++ b/src/polyforge/__init__.py
@@ -107,6 +107,7 @@ from polyforge.models import (
     VenueComparison,
     VenueComparisonDetail,
     VenuePreferences,
+    UserPreferences,  # cross-SDK alias
     SupportTicket,
     TicketMessage,
     CorrelationCategoriesReport,
@@ -226,6 +227,7 @@ __all__ = [
     "VenueComparison",
     "VenueComparisonDetail",
     "VenuePreferences",
+    "UserPreferences",  # cross-SDK alias
     "WatchlistItem",
     "Webhook",
     "WebhookTestResult",

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -229,6 +229,7 @@ _MODEL_REGISTRY: dict[str, type] = {
     "EventNotificationPref": EventNotificationPref,
     "EventNotificationPreferences": EventNotificationPreferences,
     "VenuePreferences": VenuePreferences,
+    "UserPreferences": VenuePreferences,  # cross-SDK alias
     "SupportTicket": SupportTicket,
     "TicketMessage": TicketMessage,
     "CorrelationCategoriesReport": CorrelationCategoriesReport,
@@ -3422,6 +3423,24 @@ class PolyforgeClient:
             self._patch("/api/v1/users/me/venue-preferences", json=body),
         )
 
+    def get_my_preferences(self) -> VenuePreferences:
+        """Get the authenticated user's venue/platform preferences."""
+        return self.get_venue_preferences()
+
+    def update_my_preferences(
+        self,
+        *,
+        default_venue: str | None = None,
+        enabled_venues: list[str] | None = None,
+        single_platform_mode: bool | None = None,
+    ) -> VenuePreferences:
+        """Update the authenticated user's venue/platform preferences."""
+        return self.update_venue_preferences(
+            default_venue=default_venue,
+            enabled_venues=enabled_venues,
+            single_platform_mode=single_platform_mode,
+        )
+
     # -- Sports Markets --
 
     def list_sports_categories(self) -> list[dict[str, Any]]:
@@ -6516,6 +6535,24 @@ class AsyncPolyforgeClient:
         return _parse(
             VenuePreferences,
             await self._patch("/api/v1/users/me/venue-preferences", json=body),
+        )
+
+    async def get_my_preferences(self) -> VenuePreferences:
+        """Get the authenticated user's venue/platform preferences."""
+        return await self.get_venue_preferences()
+
+    async def update_my_preferences(
+        self,
+        *,
+        default_venue: str | None = None,
+        enabled_venues: list[str] | None = None,
+        single_platform_mode: bool | None = None,
+    ) -> VenuePreferences:
+        """Update the authenticated user's venue/platform preferences."""
+        return await self.update_venue_preferences(
+            default_venue=default_venue,
+            enabled_venues=enabled_venues,
+            single_platform_mode=single_platform_mode,
         )
 
     # -- Sports Markets --

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -1561,6 +1561,10 @@ class VenuePreferences:
     single_platform_mode: bool = False
 
 
+UserPreferences = VenuePreferences
+"""Alias for cross-SDK compatibility (TS: UserPreferences, Rust: UserPreferences)."""
+
+
 # ---------------------------------------------------------------------------
 # Support Tickets
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5821,6 +5821,8 @@ class TestVenuePreferenceMethods:
     VENUE_METHODS = [
         "get_venue_preferences",
         "update_venue_preferences",
+        "get_my_preferences",
+        "update_my_preferences",
     ]
 
     @pytest.mark.parametrize("method", VENUE_METHODS)
@@ -5835,13 +5837,16 @@ class TestVenuePreferenceMethods:
 
     def test_sync_endpoints_use_correct_paths(self):
         import inspect
-        for method_name in self.VENUE_METHODS:
+        # Only check source methods that directly contain the path (not aliases)
+        base_methods = ["get_venue_preferences", "update_venue_preferences"]
+        for method_name in base_methods:
             source = inspect.getsource(getattr(PolyforgeClient, method_name))
             assert "/api/v1/users/me/venue-preferences" in source
 
     def test_async_endpoints_use_correct_paths(self):
         import inspect
-        for method_name in self.VENUE_METHODS:
+        base_methods = ["get_venue_preferences", "update_venue_preferences"]
+        for method_name in base_methods:
             source = inspect.getsource(getattr(AsyncPolyforgeClient, method_name))
             assert "/api/v1/users/me/venue-preferences" in source
 
@@ -5877,6 +5882,43 @@ class TestVenuePreferenceMethods:
         assert isinstance(result, VenuePreferences)
         assert result.single_platform_mode is True
         client.close()
+
+    def test_sync_get_my_preferences(self):
+        from unittest.mock import MagicMock
+        from polyforge.models import VenuePreferences
+        client = PolyforgeClient(api_key="test-key")
+        client._get = MagicMock(return_value={
+            "defaultVenue": "polymarket",
+            "enabledVenues": ["polymarket", "kalshi"],
+            "singlePlatformMode": False,
+        })
+        result = client.get_my_preferences()
+        assert isinstance(result, VenuePreferences)
+        assert result.default_venue == "polymarket"
+        assert "kalshi" in result.enabled_venues
+        client.close()
+
+    def test_sync_update_my_preferences(self):
+        from unittest.mock import MagicMock
+        from polyforge.models import VenuePreferences
+        client = PolyforgeClient(api_key="test-key")
+        client._patch = MagicMock(return_value={
+            "defaultVenue": "kalshi",
+            "enabledVenues": ["kalshi"],
+            "singlePlatformMode": True,
+        })
+        result = client.update_my_preferences(default_venue="kalshi", single_platform_mode=True)
+        client._patch.assert_called_once_with(
+            "/api/v1/users/me/venue-preferences",
+            json={"defaultVenue": "kalshi", "singlePlatformMode": True},
+        )
+        assert isinstance(result, VenuePreferences)
+        assert result.single_platform_mode is True
+        client.close()
+
+    def test_user_preferences_alias(self):
+        from polyforge.models import VenuePreferences, UserPreferences
+        assert UserPreferences is VenuePreferences
 
 
 class TestUserManagementModels:


### PR DESCRIPTION
## Summary
- Adds get_my_preferences() and update_my_preferences() as cross-SDK compatibility aliases
- Adds UserPreferences type alias matching sdk-ts and sdk-rust naming
- Registers UserPreferences in model registry and public exports

## Verification
- All 940 tests pass
- 15 new venue preference tests pass