### PR TITLE
fix(sdk-python): change bulk_cancel_orders from DELETE to POST (#247)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -775,7 +775,7 @@ class PolyforgeClient:
             return None
         return resp.json()
 
-    def _delete_json(
+    def _post_json(
         self,
         path: str,
         *,
@@ -783,7 +783,7 @@ class PolyforgeClient:
         idempotency_key: str | None = None,
     ) -> Any:
         resp = self._client.request(
-            "DELETE",
+            "POST",
             path,
             json=json,
             headers=_idempotency_headers(idempotency_key),
@@ -1696,7 +1696,7 @@ class PolyforgeClient:
             raise ValueError("bulk_cancel_orders requires at least 1 order ID")
         if len(order_ids) > 3000:
             raise ValueError("bulk_cancel_orders accepts at most 3000 order IDs")
-        data = self._delete_json(
+        data = self._post_json(
             "/api/v1/orders/bulk",
             json={"orderIds": order_ids},
             idempotency_key=_new_idempotency_key(idempotency_key),
@@ -4196,7 +4196,7 @@ class AsyncPolyforgeClient:
             return None
         return resp.json()
 
-    async def _delete_json(
+    async def _post_json(
         self,
         path: str,
         *,
@@ -4204,7 +4204,7 @@ class AsyncPolyforgeClient:
         idempotency_key: str | None = None,
     ) -> Any:
         resp = await self._client.request(
-            "DELETE",
+            "POST",
             path,
             json=json,
             headers=_idempotency_headers(idempotency_key),
@@ -5079,7 +5079,7 @@ class AsyncPolyforgeClient:
             raise ValueError("bulk_cancel_orders requires at least 1 order ID")
         if len(order_ids) > 3000:
             raise ValueError("bulk_cancel_orders accepts at most 3000 order IDs")
-        data = await self._delete_json(
+        data = await self._post_json(
             "/api/v1/orders/bulk",
             json={"orderIds": order_ids},
             idempotency_key=_new_idempotency_key(idempotency_key),

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -1348,7 +1348,7 @@ class BulkCancelError:
 
 @dataclass
 class BulkCancelResult:
-    """Response from DELETE /api/v1/orders/bulk."""
+    """Response from POST /api/v1/orders/bulk."""
 
     cancelled: list[str] = field(default_factory=list)
     errors: list[BulkCancelError] = field(default_factory=list)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3938,10 +3938,10 @@ class TestBulkOrderEndpoints:
         source = inspect.getsource(PolyforgeClient.bulk_cancel_orders)
         assert "/api/v1/orders/bulk" in source
 
-    def test_bulk_cancel_orders_uses_delete_json(self):
+    def test_bulk_cancel_orders_uses_post_json(self):
         import inspect
         source = inspect.getsource(PolyforgeClient.bulk_cancel_orders)
-        assert "_delete_json" in source
+        assert "_post_json" in source
 
     def test_bulk_cancel_orders_sends_order_ids_key(self):
         import inspect
@@ -7665,7 +7665,7 @@ class TestIdempotencyKeyHeaders:
             ("_post", {"results": []}, lambda c: c.batch_orders([{
                 "tokenId": "tok", "side": "BUY", "outcome": "YES", "size": 1.0, "price": 0.5,
             }])),
-            ("_delete_json", {"cancelled": [], "errors": []}, lambda c: c.bulk_cancel_orders(["ord-1"])),
+            ("_post_json", {"cancelled": [], "errors": []}, lambda c: c.bulk_cancel_orders(["ord-1"])),
             ("_post", place_order_payload, lambda c: c.close_position("tok")),
             ("_post", {"positionId": "pos-1", "intentId": "int-1", "status": "REDEEMED"}, lambda c: c.redeem_position(position_id="pos-1")),
             ("_post", place_order_payload, lambda c: c.split_position("tok", 1)),
@@ -7733,7 +7733,7 @@ class TestIdempotencyKeyHeaders:
                 ("_post", {"results": []}, lambda c: c.batch_orders([{
                     "tokenId": "tok", "side": "BUY", "outcome": "YES", "size": 1.0, "price": 0.5,
                 }])),
-                ("_delete_json", {"cancelled": [], "errors": []}, lambda c: c.bulk_cancel_orders(["ord-1"])),
+                ("_post_json", {"cancelled": [], "errors": []}, lambda c: c.bulk_cancel_orders(["ord-1"])),
                 ("_post", place_order_payload, lambda c: c.close_position("tok")),
                 ("_post", {"positionId": "pos-1", "intentId": "int-1", "status": "REDEEMED"}, lambda c: c.redeem_position(position_id="pos-1")),
                 ("_post", place_order_payload, lambda c: c.split_position("tok", 1)),


### PR DESCRIPTION
## Summary
- Changes `bulk_cancel_orders` from `DELETE /api/v1/orders/bulk` to `POST /api/v1/orders/bulk`
- Renames internal `_delete_json` helper to `_post_json` with POST method
- Updates `BulkCancelResult` docstring and test references

## Why
HTTP DELETE with a JSON body is silently stripped by many reverse proxies (nginx, AWS ALB, CloudFront). This causes `bulk_cancel_orders` to fail silently behind such proxies.

The companion platform PR adds a `POST /api/v1/orders/bulk` handler to accept the new method.

## Related
- POLA-4258
- Platform PR: https://github.com/F4CTE/PolyForge/pull/1448