### PR TITLE
fix(sdk-python): add kalshi_subaccount parameter to create_strategy and update_strategy (POLA-4561)

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1112,6 +1112,7 @@ class PolyforgeClient:
         safety: list[dict[str, Any]] | None = None,
         logic_blocks: list[dict[str, Any]] | None = None,
         calc_blocks: list[dict[str, Any]] | None = None,
+        kalshi_subaccount: str | None = None,
         tags: list[str] | None = None,
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
@@ -1131,6 +1132,7 @@ class PolyforgeClient:
             safety: Safety block definitions.
             logic_blocks: Logic block definitions.
             calc_blocks: Calc block definitions.
+            kalshi_subaccount: Kalshi subaccount identifier for P&L attribution.
             tags: Strategy tags.
             variables: Strategy variable definitions.
             canvas: Canvas layout metadata.
@@ -1158,6 +1160,8 @@ class PolyforgeClient:
             body["logicBlocks"] = logic_blocks
         if calc_blocks is not None:
             body["calcBlocks"] = calc_blocks
+        if kalshi_subaccount is not None:
+            body["kalshiSubaccount"] = kalshi_subaccount
         if tags is not None:
             body["tags"] = tags
         if variables is not None:
@@ -1208,6 +1212,7 @@ class PolyforgeClient:
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
         market_slots: list[dict[str, Any]] | None = None,
+        kalshi_subaccount: str | None = None,
     ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
@@ -1242,6 +1247,8 @@ class PolyforgeClient:
             body["canvas"] = canvas
         if market_slots is not None:
             body["marketSlots"] = market_slots
+        if kalshi_subaccount is not None:
+            body["kalshiSubaccount"] = kalshi_subaccount
         return _parse(Strategy, self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
     def delete_strategy(self, strategy_id: str) -> None:
@@ -4677,6 +4684,7 @@ class AsyncPolyforgeClient:
         safety: list[dict[str, Any]] | None = None,
         logic_blocks: list[dict[str, Any]] | None = None,
         calc_blocks: list[dict[str, Any]] | None = None,
+        kalshi_subaccount: str | None = None,
         tags: list[str] | None = None,
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
@@ -4705,6 +4713,8 @@ class AsyncPolyforgeClient:
             body["logicBlocks"] = logic_blocks
         if calc_blocks is not None:
             body["calcBlocks"] = calc_blocks
+        if kalshi_subaccount is not None:
+            body["kalshiSubaccount"] = kalshi_subaccount
         if tags is not None:
             body["tags"] = tags
         if variables is not None:
@@ -4755,6 +4765,7 @@ class AsyncPolyforgeClient:
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
         market_slots: list[dict[str, Any]] | None = None,
+        kalshi_subaccount: str | None = None,
     ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
@@ -4789,6 +4800,8 @@ class AsyncPolyforgeClient:
             body["canvas"] = canvas
         if market_slots is not None:
             body["marketSlots"] = market_slots
+        if kalshi_subaccount is not None:
+            body["kalshiSubaccount"] = kalshi_subaccount
         return _parse(Strategy, await self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
     async def delete_strategy(self, strategy_id: str) -> None:

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -162,6 +162,7 @@ class Strategy:
     safety: list[StrategyBlock] = field(default_factory=list)
     logic_blocks: list[dict[str, Any]] = field(default_factory=list)
     calc_blocks: list[dict[str, Any]] = field(default_factory=list)
+    kalshi_subaccount: str | None = None
     # Strategy metadata (#31)
     visibility: str = "PRIVATE"
     exec_mode: str = "TICK"

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -162,7 +162,6 @@ class Strategy:
     safety: list[StrategyBlock] = field(default_factory=list)
     logic_blocks: list[dict[str, Any]] = field(default_factory=list)
     calc_blocks: list[dict[str, Any]] = field(default_factory=list)
-    kalshi_subaccount: str | None = None
     # Strategy metadata (#31)
     visibility: str = "PRIVATE"
     exec_mode: str = "TICK"
@@ -175,6 +174,7 @@ class Strategy:
     blocks: list[StrategyBlock] = field(default_factory=list)
     created_at: str = ""
     updated_at: str = ""
+    kalshi_subaccount: str | None = None
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1313,6 +1313,7 @@ class TestCreateStrategyParams:
         assert "tags" in params
         assert "variables" in params
         assert "canvas" in params
+        assert "kalshi_subaccount" in params
 
     def test_async_create_strategy_accepts_block_params(self):
         """Async create_strategy() must also accept the expanded params."""
@@ -1324,6 +1325,7 @@ class TestCreateStrategyParams:
         assert "triggers" in params
         assert "actions" in params
         assert "tags" in params
+        assert "kalshi_subaccount" in params
 
     def test_create_strategy_sends_camel_case_fields(self):
         """create_strategy() must send camelCase field names to the API."""
@@ -1337,6 +1339,7 @@ class TestCreateStrategyParams:
         assert '"actions"' in source
         assert '"safety"' in source
         assert '"tags"' in source
+        assert '"kalshiSubaccount"' in source
 
 
 class TestUpdateStrategyParams:
@@ -1351,7 +1354,7 @@ class TestUpdateStrategyParams:
             "name", "description", "market_id", "visibility", "exec_mode",
             "tick_ms", "triggers", "conditions", "actions", "safety",
             "logic_blocks", "calc_blocks", "tags", "variables", "canvas",
-            "market_slots",
+            "market_slots", "kalshi_subaccount",
         ):
             assert expected in params, f"missing param: {expected}"
 
@@ -1364,7 +1367,7 @@ class TestUpdateStrategyParams:
             "name", "description", "market_id", "visibility", "exec_mode",
             "tick_ms", "triggers", "conditions", "actions", "safety",
             "logic_blocks", "calc_blocks", "tags", "variables", "canvas",
-            "market_slots",
+            "market_slots", "kalshi_subaccount",
         ):
             assert expected in params, f"missing async param: {expected}"
 
@@ -1376,7 +1379,7 @@ class TestUpdateStrategyParams:
             '"visibility"', '"execMode"', '"tickMs"', '"triggers"',
             '"conditions"', '"actions"', '"safety"', '"logicBlocks"',
             '"calcBlocks"', '"tags"', '"variables"', '"canvas"',
-            '"marketSlots"',
+            '"marketSlots"', '"kalshiSubaccount"',
         ):
             assert camel in source, f"missing camelCase key: {camel}"
 


### PR DESCRIPTION
## Summary
- Adds kalshi_subaccount to Strategy dataclass
- Adds parameter to create_strategy() and update_strategy() (sync + async)
- Serializes as kalshiSubaccount (camelCase) in JSON bodies
- Adds test assertions for parameter presence and wire format

## Verification
- All 954 tests pass
- Cross-SDK parity with polyforge-sdk-ts#240