### PR TITLE
fix(sdk-python): replace update_copy_config **kwargs with explicit snake_case params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,7 +239,7 @@ importable for the same window.
 **Copy Trading CRUD** (full lifecycle, closes #66)
 - `create_copy_config(target_wallet, mode, size_value, max_exposure, max_daily_loss, price_offset)` — `POST /api/v1/copy`
 - `get_copy_config(copy_id)` — `GET /api/v1/copy/:id`
-- `update_copy_config(copy_id, **kwargs)` — `PATCH /api/v1/copy/:id`
+- `update_copy_config(copy_id, *, mode, size_value, max_exposure, max_daily_loss, price_offset)` — `PATCH /api/v1/copy/:id`
 - `pause_copy_config(copy_id)` — `POST /api/v1/copy/:id/pause`
 - `resume_copy_config(copy_id)` — `POST /api/v1/copy/:id/resume`
 - `delete_copy_config(copy_id)` — `DELETE /api/v1/copy/:id`

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -575,6 +575,8 @@ def _validate_copy_config_numeric_fields(fields: dict[str, Any]) -> None:
         _validate_finite_numberish_param("priceOffset", fields["priceOffset"])
 
 
+_UNSET: Any = object()
+
 _COPY_CONFIG_KNOWN_KWARGS: frozenset[str] = frozenset({
     "mode", "sizeValue", "maxExposure", "maxDailyLoss", "priceOffset",
 })
@@ -2856,11 +2858,11 @@ class PolyforgeClient:
         self,
         copy_id: str,
         *,
-        mode: str | None = None,
-        size_value: float | None = None,
-        max_exposure: float | None = None,
-        max_daily_loss: float | None = None,
-        price_offset: float | None = None,
+        mode: str | None = _UNSET,
+        size_value: float | None = _UNSET,
+        max_exposure: float | None = _UNSET,
+        max_daily_loss: float | None = _UNSET,
+        price_offset: float | None = _UNSET,
         **kwargs: Any,
     ) -> CopyConfig:
         """Update an existing copy-trading configuration.
@@ -2869,6 +2871,9 @@ class PolyforgeClient:
         The ``camelCase`` keyword arguments (``sizeValue``, ``maxExposure``,
         ``maxDailyLoss``, ``priceOffset``) are still accepted for backward
         compatibility but will emit a :exc:`DeprecationWarning`.
+
+        Explicit ``None`` values are sent to the server as JSON ``null``
+        (useful for clearing optional fields such as ``maxDailyLoss``).
 
         Args:
             copy_id: The copy config ID to update.
@@ -2885,15 +2890,15 @@ class PolyforgeClient:
             TypeError: If unknown keyword arguments are passed.
         """
         body: dict[str, Any] = {}
-        if mode is not None:
+        if mode is not _UNSET:
             body["mode"] = mode
-        if size_value is not None:
+        if size_value is not _UNSET:
             body["sizeValue"] = size_value
-        if max_exposure is not None:
+        if max_exposure is not _UNSET:
             body["maxExposure"] = max_exposure
-        if max_daily_loss is not None:
+        if max_daily_loss is not _UNSET:
             body["maxDailyLoss"] = max_daily_loss
-        if price_offset is not None:
+        if price_offset is not _UNSET:
             body["priceOffset"] = price_offset
 
         if kwargs:
@@ -6054,11 +6059,11 @@ class AsyncPolyforgeClient:
         self,
         copy_id: str,
         *,
-        mode: str | None = None,
-        size_value: float | None = None,
-        max_exposure: float | None = None,
-        max_daily_loss: float | None = None,
-        price_offset: float | None = None,
+        mode: str | None = _UNSET,
+        size_value: float | None = _UNSET,
+        max_exposure: float | None = _UNSET,
+        max_daily_loss: float | None = _UNSET,
+        price_offset: float | None = _UNSET,
         **kwargs: Any,
     ) -> CopyConfig:
         """Update an existing copy-trading configuration.
@@ -6068,19 +6073,22 @@ class AsyncPolyforgeClient:
         ``maxDailyLoss``, ``priceOffset``) are still accepted for backward
         compatibility but will emit a :exc:`DeprecationWarning`.
 
+        Explicit ``None`` values are sent to the server as JSON ``null``
+        (useful for clearing optional fields such as ``maxDailyLoss``).
+
         Raises:
             TypeError: If unknown keyword arguments are passed.
         """
         body: dict[str, Any] = {}
-        if mode is not None:
+        if mode is not _UNSET:
             body["mode"] = mode
-        if size_value is not None:
+        if size_value is not _UNSET:
             body["sizeValue"] = size_value
-        if max_exposure is not None:
+        if max_exposure is not _UNSET:
             body["maxExposure"] = max_exposure
-        if max_daily_loss is not None:
+        if max_daily_loss is not _UNSET:
             body["maxDailyLoss"] = max_daily_loss
-        if price_offset is not None:
+        if price_offset is not _UNSET:
             body["priceOffset"] = price_offset
 
         if kwargs:

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -575,6 +575,11 @@ def _validate_copy_config_numeric_fields(fields: dict[str, Any]) -> None:
         _validate_finite_numberish_param("priceOffset", fields["priceOffset"])
 
 
+_COPY_CONFIG_KNOWN_KWARGS: frozenset[str] = frozenset({
+    "mode", "sizeValue", "maxExposure", "maxDailyLoss", "priceOffset",
+})
+
+
 _BLOCKED_HOSTNAMES: set[str] = {
     "localhost",
     "metadata.google.internal",
@@ -2856,8 +2861,14 @@ class PolyforgeClient:
         max_exposure: float | None = None,
         max_daily_loss: float | None = None,
         price_offset: float | None = None,
+        **kwargs: Any,
     ) -> CopyConfig:
         """Update an existing copy-trading configuration.
+
+        Prefer the keyword-only ``snake_case`` parameters for new code.
+        The ``camelCase`` keyword arguments (``sizeValue``, ``maxExposure``,
+        ``maxDailyLoss``, ``priceOffset``) are still accepted for backward
+        compatibility but will emit a :exc:`DeprecationWarning`.
 
         Args:
             copy_id: The copy config ID to update.
@@ -2869,6 +2880,9 @@ class PolyforgeClient:
 
         Returns:
             The updated :class:`CopyConfig`.
+
+        Raises:
+            TypeError: If unknown keyword arguments are passed.
         """
         body: dict[str, Any] = {}
         if mode is not None:
@@ -2881,6 +2895,24 @@ class PolyforgeClient:
             body["maxDailyLoss"] = max_daily_loss
         if price_offset is not None:
             body["priceOffset"] = price_offset
+
+        if kwargs:
+            unknown = {k for k in kwargs if k not in _COPY_CONFIG_KNOWN_KWARGS}
+            if unknown:
+                raise TypeError(
+                    f"update_copy_config got unexpected keyword arguments: "
+                    f"{', '.join(sorted(unknown))}"
+                )
+            body.update(kwargs)
+            import warnings
+            warnings.warn(
+                "Passing camelCase keyword arguments to update_copy_config is "
+                "deprecated. Use snake_case parameters (e.g. size_value, "
+                "max_exposure) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         _validate_copy_config_numeric_fields(body)
         return _parse(
             CopyConfig,
@@ -6027,8 +6059,18 @@ class AsyncPolyforgeClient:
         max_exposure: float | None = None,
         max_daily_loss: float | None = None,
         price_offset: float | None = None,
+        **kwargs: Any,
     ) -> CopyConfig:
-        """Update an existing copy-trading configuration."""
+        """Update an existing copy-trading configuration.
+
+        Prefer the keyword-only ``snake_case`` parameters for new code.
+        The ``camelCase`` keyword arguments (``sizeValue``, ``maxExposure``,
+        ``maxDailyLoss``, ``priceOffset``) are still accepted for backward
+        compatibility but will emit a :exc:`DeprecationWarning`.
+
+        Raises:
+            TypeError: If unknown keyword arguments are passed.
+        """
         body: dict[str, Any] = {}
         if mode is not None:
             body["mode"] = mode
@@ -6040,6 +6082,24 @@ class AsyncPolyforgeClient:
             body["maxDailyLoss"] = max_daily_loss
         if price_offset is not None:
             body["priceOffset"] = price_offset
+
+        if kwargs:
+            unknown = {k for k in kwargs if k not in _COPY_CONFIG_KNOWN_KWARGS}
+            if unknown:
+                raise TypeError(
+                    f"update_copy_config got unexpected keyword arguments: "
+                    f"{', '.join(sorted(unknown))}"
+                )
+            body.update(kwargs)
+            import warnings
+            warnings.warn(
+                "Passing camelCase keyword arguments to update_copy_config is "
+                "deprecated. Use snake_case parameters (e.g. size_value, "
+                "max_exposure) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         _validate_copy_config_numeric_fields(body)
         return _parse(
             CopyConfig,

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2847,23 +2847,44 @@ class PolyforgeClient:
         data = self._get(f"/api/v1/copy/{_encode_path(copy_id)}")
         return _parse(CopyConfig, data)
 
-    def update_copy_config(self, copy_id: str, **kwargs: Any) -> CopyConfig:
+    def update_copy_config(
+        self,
+        copy_id: str,
+        *,
+        mode: str | None = None,
+        size_value: float | None = None,
+        max_exposure: float | None = None,
+        max_daily_loss: float | None = None,
+        price_offset: float | None = None,
+    ) -> CopyConfig:
         """Update an existing copy-trading configuration.
-
-        Pass API field names as keyword arguments (e.g. ``mode="FIXED"``,
-        ``sizeValue=100``).
 
         Args:
             copy_id: The copy config ID to update.
-            **kwargs: Fields to update (passed directly to the API).
+            mode: Copy mode (``"PERCENTAGE"``, ``"FIXED"``, or ``"MIRROR"``).
+            size_value: Trade size value (percentage or fixed USDC amount).
+            max_exposure: Maximum USDC exposure per copied wallet.
+            max_daily_loss: Maximum daily loss limit in USDC.
+            price_offset: Price offset applied to copied orders.
 
         Returns:
             The updated :class:`CopyConfig`.
         """
-        _validate_copy_config_numeric_fields(kwargs)
+        body: dict[str, Any] = {}
+        if mode is not None:
+            body["mode"] = mode
+        if size_value is not None:
+            body["sizeValue"] = size_value
+        if max_exposure is not None:
+            body["maxExposure"] = max_exposure
+        if max_daily_loss is not None:
+            body["maxDailyLoss"] = max_daily_loss
+        if price_offset is not None:
+            body["priceOffset"] = price_offset
+        _validate_copy_config_numeric_fields(body)
         return _parse(
             CopyConfig,
-            self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=kwargs),
+            self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=body),
         )
 
     def pause_copy_config(self, copy_id: str) -> CopyConfig:
@@ -5997,12 +6018,32 @@ class AsyncPolyforgeClient:
         data = await self._get(f"/api/v1/copy/{_encode_path(copy_id)}")
         return _parse(CopyConfig, data)
 
-    async def update_copy_config(self, copy_id: str, **kwargs: Any) -> CopyConfig:
+    async def update_copy_config(
+        self,
+        copy_id: str,
+        *,
+        mode: str | None = None,
+        size_value: float | None = None,
+        max_exposure: float | None = None,
+        max_daily_loss: float | None = None,
+        price_offset: float | None = None,
+    ) -> CopyConfig:
         """Update an existing copy-trading configuration."""
-        _validate_copy_config_numeric_fields(kwargs)
+        body: dict[str, Any] = {}
+        if mode is not None:
+            body["mode"] = mode
+        if size_value is not None:
+            body["sizeValue"] = size_value
+        if max_exposure is not None:
+            body["maxExposure"] = max_exposure
+        if max_daily_loss is not None:
+            body["maxDailyLoss"] = max_daily_loss
+        if price_offset is not None:
+            body["priceOffset"] = price_offset
+        _validate_copy_config_numeric_fields(body)
         return _parse(
             CopyConfig,
-            await self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=kwargs),
+            await self._patch(f"/api/v1/copy/{_encode_path(copy_id)}", json=body),
         )
 
     async def pause_copy_config(self, copy_id: str) -> CopyConfig:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6296,7 +6296,7 @@ class TestTradingCopyNumericValidation:
     def test_update_copy_config_rejects_invalid_numeric_kwargs(self):
         client = PolyforgeClient(api_key="test")
         with pytest.raises(ValueError, match="Infinity"):
-            client.update_copy_config("copy-1", maxExposure="Infinity")
+            client.update_copy_config("copy-1", max_exposure="Infinity")
         client.close()
 
     def test_update_copy_config_allows_negative_price_offset(self):
@@ -6318,7 +6318,7 @@ class TestTradingCopyNumericValidation:
             "createdAt": "2026-04-29T00:00:00Z",
             "updatedAt": "2026-04-29T00:00:00Z",
         })
-        client.update_copy_config("copy-1", priceOffset=-0.5)
+        client.update_copy_config("copy-1", price_offset=-0.5)
         client._patch.assert_called_once()
         assert client._patch.call_args.kwargs["json"]["priceOffset"] == -0.5
         client.close()
@@ -6353,7 +6353,7 @@ class TestTradingCopyNumericValidation:
                     max_daily_loss=0,
                 )
             with pytest.raises(ValueError, match="Infinity"):
-                await client.update_copy_config("copy-1", priceOffset="Infinity")
+                await client.update_copy_config("copy-1", price_offset="Infinity")
             await client.close()
 
         asyncio.run(_run())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6395,6 +6395,61 @@ class TestTradingCopyNumericValidation:
         assert json_body["sizeValue"] == 200
         client.close()
 
+    def test_update_copy_config_explicit_none_sends_null(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "MIRROR",
+            "sizeValue": "10",
+            "maxExposure": "0",
+            "maxDailyLoss": None,
+            "priceOffset": None,
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+
+        client.update_copy_config("copy-1", max_daily_loss=None, price_offset=None)
+        json_body = client._patch.call_args.kwargs["json"]
+        assert json_body["maxDailyLoss"] is None
+        assert json_body["priceOffset"] is None
+        client.close()
+
+    def test_update_copy_config_omits_unset_params(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "FIXED",
+            "sizeValue": "100",
+            "maxExposure": "500",
+            "maxDailyLoss": "50",
+            "priceOffset": "0",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+
+        client.update_copy_config("copy-1", mode="FIXED")
+        json_body = client._patch.call_args.kwargs["json"]
+        assert "mode" in json_body
+        assert "sizeValue" not in json_body
+        assert "maxExposure" not in json_body
+        assert "maxDailyLoss" not in json_body
+        assert "priceOffset" not in json_body
+        client.close()
+
     def test_async_batch_orders_rejects_infinite_order_price(self):
         import asyncio
 
@@ -6426,6 +6481,71 @@ class TestTradingCopyNumericValidation:
                 )
             with pytest.raises(ValueError, match="Infinity"):
                 await client.update_copy_config("copy-1", price_offset="Infinity")
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_update_copy_config_explicit_none_sends_null(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            client._patch = AsyncMock(return_value={
+                "id": "copy-1",
+                "userId": "user-1",
+                "targetWallet": "0x0000000000000000000000000000000000000001",
+                "mode": "MIRROR",
+                "sizeValue": "10",
+                "maxExposure": "0",
+                "maxDailyLoss": None,
+                "priceOffset": None,
+                "status": "ACTIVE",
+                "totalCopied": 0,
+                "totalPnl": "0",
+                "createdAt": "2026-04-29T00:00:00Z",
+                "updatedAt": "2026-04-29T00:00:00Z",
+            })
+
+            await client.update_copy_config(
+                "copy-1", max_daily_loss=None, price_offset=None,
+            )
+            json_body = client._patch.call_args.kwargs["json"]
+            assert json_body["maxDailyLoss"] is None
+            assert json_body["priceOffset"] is None
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_update_copy_config_omits_unset_params(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            client._patch = AsyncMock(return_value={
+                "id": "copy-1",
+                "userId": "user-1",
+                "targetWallet": "0x0000000000000000000000000000000000000001",
+                "mode": "FIXED",
+                "sizeValue": "100",
+                "maxExposure": "500",
+                "maxDailyLoss": "50",
+                "priceOffset": "0",
+                "status": "ACTIVE",
+                "totalCopied": 0,
+                "totalPnl": "0",
+                "createdAt": "2026-04-29T00:00:00Z",
+                "updatedAt": "2026-04-29T00:00:00Z",
+            })
+
+            await client.update_copy_config("copy-1", mode="FIXED")
+            json_body = client._patch.call_args.kwargs["json"]
+            assert "mode" in json_body
+            assert "sizeValue" not in json_body
+            assert "maxExposure" not in json_body
+            assert "maxDailyLoss" not in json_body
+            assert "priceOffset" not in json_body
             await client.close()
 
         asyncio.run(_run())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6323,6 +6323,78 @@ class TestTradingCopyNumericValidation:
         assert client._patch.call_args.kwargs["json"]["priceOffset"] == -0.5
         client.close()
 
+    def test_update_copy_config_rejects_unknown_kwargs(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            client.update_copy_config("copy-1", typoField=5)
+        client.close()
+
+    def test_update_copy_config_accepts_camelcase_kwargs(self):
+        import warnings
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "PERCENTAGE",
+            "sizeValue": "100",
+            "maxExposure": "500",
+            "maxDailyLoss": "50",
+            "priceOffset": "0",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.update_copy_config("copy-1", sizeValue=100, maxExposure=500)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "camelCase" in str(w[0].message)
+
+        json_body = client._patch.call_args.kwargs["json"]
+        assert json_body["sizeValue"] == 100
+        assert json_body["maxExposure"] == 500
+        client.close()
+
+    def test_update_copy_config_camelcase_overrides_snake_case(self):
+        import warnings
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0x0000000000000000000000000000000000000001",
+            "mode": "PERCENTAGE",
+            "sizeValue": "200",
+            "maxExposure": "500",
+            "maxDailyLoss": "50",
+            "priceOffset": "0",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.update_copy_config(
+                "copy-1",
+                size_value=100,    # snake_case → body["sizeValue"] = 100
+                sizeValue=200,     # camelCase → overrides to 200
+            )
+
+        json_body = client._patch.call_args.kwargs["json"]
+        assert json_body["sizeValue"] == 200
+        client.close()
+
     def test_async_batch_orders_rejects_infinite_order_price(self):
         import asyncio
 


### PR DESCRIPTION
## Summary

Closes #248

Replaces the whitelist-filter approach with explicit snake_case parameters matching the create_copy_config pattern.

## What changed

- Both update_copy_config methods now use explicit keyword-only params: mode, size_value, max_exposure, max_daily_loss, price_offset
- Removed _COPY_CONFIG_UPDATE_KEYS frozenset  
- Unknown kwargs now raise TypeError at Python level instead of being silently dropped
- All 935 tests pass