### PR TITLE
fix(sdk-python): cap watch_strategy SSE line buffer

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -7558,10 +7558,10 @@ def _iter_sse_lines(chunks: Iterator[bytes]) -> Iterator[str]:
             pending.clear()
             start = delimiter_index + 1
             if chunk[delimiter_index] == 13:
-                if start < len(chunk) and chunk[start] == 10:
-                    start += 1
-                else:
+                if start == len(chunk):
                     skip_next_lf = True
+                elif chunk[start] == 10:
+                    start += 1
     if pending:
         yield pending.decode("utf-8", errors="replace")
 
@@ -7597,10 +7597,10 @@ async def _aiter_sse_lines(chunks: AsyncIterator[bytes]) -> AsyncIterator[str]:
             pending.clear()
             start = delimiter_index + 1
             if chunk[delimiter_index] == 13:
-                if start < len(chunk) and chunk[start] == 10:
-                    start += 1
-                else:
+                if start == len(chunk):
                     skip_next_lf = True
+                elif chunk[start] == 10:
+                    start += 1
     if pending:
         yield pending.decode("utf-8", errors="replace")
 

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2456,7 +2456,7 @@ class PolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            for line in _iter_sse_lines(response.iter_bytes(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+            for line in _iter_sse_lines(response.iter_bytes()):
                 event = _parse_strategy_sse_line(line)
                 if event is not None:
                     yield event
@@ -5946,7 +5946,7 @@ class AsyncPolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            async for line in _aiter_sse_lines(response.aiter_bytes(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+            async for line in _aiter_sse_lines(response.aiter_bytes()):
                 event = _parse_strategy_sse_line(line)
                 if event is not None:
                     yield event
@@ -7517,7 +7517,6 @@ class AsyncPolyforgeClient:
 
 
 _MAX_SSE_LINE_BYTES = 64 * 1024
-_SSE_RAW_CHUNK_SIZE = 4096
 
 
 def _sse_line_too_long_error() -> PolyforgeError:
@@ -7530,46 +7529,80 @@ def _sse_line_too_long_error() -> PolyforgeError:
 
 def _iter_sse_lines(chunks: Iterator[bytes]) -> Iterator[str]:
     pending = bytearray()
+    skip_next_lf = False
     for chunk in chunks:
         if not chunk:
             continue
         start = 0
+        if skip_next_lf:
+            if chunk.startswith(b"\n"):
+                start = 1
+            skip_next_lf = False
         while start < len(chunk):
-            newline_index = chunk.find(b"\n", start)
-            end = len(chunk) if newline_index == -1 else newline_index
+            cr_index = chunk.find(b"\r", start)
+            lf_index = chunk.find(b"\n", start)
+            if cr_index == -1:
+                delimiter_index = lf_index
+            elif lf_index == -1:
+                delimiter_index = cr_index
+            else:
+                delimiter_index = min(cr_index, lf_index)
+            end = len(chunk) if delimiter_index == -1 else delimiter_index
             segment = chunk[start:end]
             if len(pending) + len(segment) > _MAX_SSE_LINE_BYTES:
                 raise _sse_line_too_long_error()
             pending.extend(segment)
-            if newline_index == -1:
+            if delimiter_index == -1:
                 break
-            yield pending.decode("utf-8", errors="replace").rstrip("\r")
+            yield pending.decode("utf-8", errors="replace")
             pending.clear()
-            start = newline_index + 1
+            start = delimiter_index + 1
+            if chunk[delimiter_index] == 13:
+                if start < len(chunk) and chunk[start] == 10:
+                    start += 1
+                else:
+                    skip_next_lf = True
     if pending:
-        yield pending.decode("utf-8", errors="replace").rstrip("\r")
+        yield pending.decode("utf-8", errors="replace")
 
 
 async def _aiter_sse_lines(chunks: AsyncIterator[bytes]) -> AsyncIterator[str]:
     pending = bytearray()
+    skip_next_lf = False
     async for chunk in chunks:
         if not chunk:
             continue
         start = 0
+        if skip_next_lf:
+            if chunk.startswith(b"\n"):
+                start = 1
+            skip_next_lf = False
         while start < len(chunk):
-            newline_index = chunk.find(b"\n", start)
-            end = len(chunk) if newline_index == -1 else newline_index
+            cr_index = chunk.find(b"\r", start)
+            lf_index = chunk.find(b"\n", start)
+            if cr_index == -1:
+                delimiter_index = lf_index
+            elif lf_index == -1:
+                delimiter_index = cr_index
+            else:
+                delimiter_index = min(cr_index, lf_index)
+            end = len(chunk) if delimiter_index == -1 else delimiter_index
             segment = chunk[start:end]
             if len(pending) + len(segment) > _MAX_SSE_LINE_BYTES:
                 raise _sse_line_too_long_error()
             pending.extend(segment)
-            if newline_index == -1:
+            if delimiter_index == -1:
                 break
-            yield pending.decode("utf-8", errors="replace").rstrip("\r")
+            yield pending.decode("utf-8", errors="replace")
             pending.clear()
-            start = newline_index + 1
+            start = delimiter_index + 1
+            if chunk[delimiter_index] == 13:
+                if start < len(chunk) and chunk[start] == 10:
+                    start += 1
+                else:
+                    skip_next_lf = True
     if pending:
-        yield pending.decode("utf-8", errors="replace").rstrip("\r")
+        yield pending.decode("utf-8", errors="replace")
 
 
 def _parse_strategy_sse_line(line: str) -> StrategyEvent | None:

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2456,7 +2456,7 @@ class PolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            for line in _iter_sse_lines(response.iter_raw(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+            for line in _iter_sse_lines(response.iter_bytes(chunk_size=_SSE_RAW_CHUNK_SIZE)):
                 event = _parse_strategy_sse_line(line)
                 if event is not None:
                     yield event
@@ -5946,7 +5946,7 @@ class AsyncPolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            async for line in _aiter_sse_lines(response.aiter_raw(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+            async for line in _aiter_sse_lines(response.aiter_bytes(chunk_size=_SSE_RAW_CHUNK_SIZE)):
                 event = _parse_strategy_sse_line(line)
                 if event is not None:
                     yield event

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2456,26 +2456,10 @@ class PolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            for line in response.iter_lines():
-                if not line.startswith("data: "):
-                    continue
-                raw = line[6:].strip()
-                if not raw:
-                    continue
-                try:
-                    payload = _json.loads(raw)
-                    # Validate expected fields before yielding
-                    if not isinstance(payload.get("type"), str):
-                        continue
-                    yield StrategyEvent(
-                        type=payload["type"],
-                        strategy_id=payload.get("strategyId", ""),
-                        data=payload.get("data"),
-                        timestamp=payload.get("timestamp", 0),
-                    )
-                except _json.JSONDecodeError:
-                    _log.warning("Malformed SSE event: failed to parse JSON")
-                    continue
+            for line in _iter_sse_lines(response.iter_raw(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+                event = _parse_strategy_sse_line(line)
+                if event is not None:
+                    yield event
 
     # -- Paper Trading --
 
@@ -5962,26 +5946,10 @@ class AsyncPolyforgeClient:
             timeout=httpx.Timeout(self._stream_timeout, connect=10.0),
         ) as response:
             _raise_for_status(response)
-            async for line in response.aiter_lines():
-                if not line.startswith("data: "):
-                    continue
-                raw = line[6:].strip()
-                if not raw:
-                    continue
-                try:
-                    payload = _json.loads(raw)
-                    # Validate expected fields before yielding
-                    if not isinstance(payload.get("type"), str):
-                        continue
-                    yield StrategyEvent(
-                        type=payload["type"],
-                        strategy_id=payload.get("strategyId", ""),
-                        data=payload.get("data"),
-                        timestamp=payload.get("timestamp", 0),
-                    )
-                except _json.JSONDecodeError:
-                    _log.warning("Malformed SSE event: failed to parse JSON")
-                    continue
+            async for line in _aiter_sse_lines(response.aiter_raw(chunk_size=_SSE_RAW_CHUNK_SIZE)):
+                event = _parse_strategy_sse_line(line)
+                if event is not None:
+                    yield event
 
     # -- Paper Trading --
 
@@ -7546,3 +7514,80 @@ class AsyncPolyforgeClient:
 
     async def __aexit__(self, *args: Any) -> None:
         await self.close()
+
+
+_MAX_SSE_LINE_BYTES = 64 * 1024
+_SSE_RAW_CHUNK_SIZE = 4096
+
+
+def _sse_line_too_long_error() -> PolyforgeError:
+    return PolyforgeError(
+        f"SSE event line exceeded {_MAX_SSE_LINE_BYTES} bytes",
+        code="SSE_LINE_TOO_LONG",
+        suggestion="The server sent an invalid event stream line.",
+    )
+
+
+def _iter_sse_lines(chunks: Iterator[bytes]) -> Iterator[str]:
+    pending = bytearray()
+    for chunk in chunks:
+        if not chunk:
+            continue
+        start = 0
+        while start < len(chunk):
+            newline_index = chunk.find(b"\n", start)
+            end = len(chunk) if newline_index == -1 else newline_index
+            segment = chunk[start:end]
+            if len(pending) + len(segment) > _MAX_SSE_LINE_BYTES:
+                raise _sse_line_too_long_error()
+            pending.extend(segment)
+            if newline_index == -1:
+                break
+            yield pending.decode("utf-8", errors="replace").rstrip("\r")
+            pending.clear()
+            start = newline_index + 1
+    if pending:
+        yield pending.decode("utf-8", errors="replace").rstrip("\r")
+
+
+async def _aiter_sse_lines(chunks: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    pending = bytearray()
+    async for chunk in chunks:
+        if not chunk:
+            continue
+        start = 0
+        while start < len(chunk):
+            newline_index = chunk.find(b"\n", start)
+            end = len(chunk) if newline_index == -1 else newline_index
+            segment = chunk[start:end]
+            if len(pending) + len(segment) > _MAX_SSE_LINE_BYTES:
+                raise _sse_line_too_long_error()
+            pending.extend(segment)
+            if newline_index == -1:
+                break
+            yield pending.decode("utf-8", errors="replace").rstrip("\r")
+            pending.clear()
+            start = newline_index + 1
+    if pending:
+        yield pending.decode("utf-8", errors="replace").rstrip("\r")
+
+
+def _parse_strategy_sse_line(line: str) -> StrategyEvent | None:
+    if not line.startswith("data: "):
+        return None
+    raw = line[6:].strip()
+    if not raw:
+        return None
+    try:
+        payload = _json.loads(raw)
+    except _json.JSONDecodeError:
+        _log.warning("Malformed SSE event: failed to parse JSON")
+        return None
+    if not isinstance(payload.get("type"), str):
+        return None
+    return StrategyEvent(
+        type=payload["type"],
+        strategy_id=payload.get("strategyId", ""),
+        data=payload.get("data"),
+        timestamp=payload.get("timestamp", 0),
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,8 @@ from polyforge.client import (
     PolyforgeClient,
     AsyncPolyforgeClient,
     _MAX_SSE_LINE_BYTES,
+    _aiter_sse_lines,
+    _iter_sse_lines,
     _parse,
     _parse_pagination,
     _raise_for_status,
@@ -6127,6 +6129,26 @@ class TestSseStreamTimeout:
         assert event.timestamp == 123
         client.close()
 
+    def test_sync_watch_strategy_uses_prompt_decoded_byte_chunks(self):
+        """watch_strategy must not buffer SSE events behind a fixed chunk_size."""
+        import inspect
+
+        source = inspect.getsource(PolyforgeClient.watch_strategy)
+        assert "iter_bytes()" in source
+        assert "iter_bytes(chunk_size" not in source
+
+    def test_sync_sse_reader_splits_cr_delimited_events(self):
+        """The bounded SSE reader must accept CR-only line delimiters."""
+        body = (
+            b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+            b'"data":{"cr":true},"timestamp":123}\r\r'
+        )
+        lines = list(_iter_sse_lines(iter([body])))
+        assert lines == [
+            'data: {"type":"CONNECTED","strategyId":"strat-1","data":{"cr":true},"timestamp":123}',
+            "",
+        ]
+
     def test_async_watch_strategy_rejects_overlong_sse_line(self):
         """async watch_strategy must not buffer an unterminated SSE line indefinitely."""
         import asyncio
@@ -6190,6 +6212,35 @@ class TestSseStreamTimeout:
             assert event.data == {"ok": True}
             assert event.timestamp == 123
             await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_watch_strategy_uses_prompt_decoded_byte_chunks(self):
+        """async watch_strategy must not buffer SSE events behind a fixed chunk_size."""
+        import inspect
+
+        source = inspect.getsource(AsyncPolyforgeClient.watch_strategy)
+        assert "aiter_bytes()" in source
+        assert "aiter_bytes(chunk_size" not in source
+
+    def test_async_sse_reader_splits_cr_delimited_events(self):
+        """The async bounded SSE reader must accept CR-only line delimiters."""
+        import asyncio
+
+        async def chunks():
+            yield (
+                b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+                b'"data":{"cr":true},"timestamp":123}\r\r'
+            )
+
+        async def _run():
+            lines = []
+            async for line in _aiter_sse_lines(chunks()):
+                lines.append(line)
+            assert lines == [
+                'data: {"type":"CONNECTED","strategyId":"strat-1","data":{"cr":true},"timestamp":123}',
+                "",
+            ]
 
         asyncio.run(_run())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 """Basic smoke tests for PolyforgeClient."""
 
+import gzip
 import json
 
 import httpx
@@ -6097,6 +6098,35 @@ class TestSseStreamTimeout:
         assert event.timestamp == 123
         client.close()
 
+    def test_sync_watch_strategy_decodes_compressed_sse_event(self):
+        """watch_strategy must frame decoded response bytes, not compressed wire bytes."""
+        body = gzip.compress(
+            b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+            b'"data":{"compressed":true},"timestamp":123}\n\n'
+        )
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                stream=httpx.ByteStream(body),
+                headers={
+                    "content-type": "text/event-stream",
+                    "content-encoding": "gzip",
+                },
+            )
+        )
+        client = PolyforgeClient(api_key="test-key")
+        client._client = httpx.Client(
+            base_url="https://api.polyforge.io",
+            headers={"Authorization": "Bearer test-key"},
+            transport=transport,
+        )
+        event = next(client.watch_strategy("strat-1"))
+        assert event.type == "CONNECTED"
+        assert event.strategy_id == "strat-1"
+        assert event.data == {"compressed": True}
+        assert event.timestamp == 123
+        client.close()
+
     def test_async_watch_strategy_rejects_overlong_sse_line(self):
         """async watch_strategy must not buffer an unterminated SSE line indefinitely."""
         import asyncio
@@ -6158,6 +6188,45 @@ class TestSseStreamTimeout:
             assert event.type == "CONNECTED"
             assert event.strategy_id == "strat-1"
             assert event.data == {"ok": True}
+            assert event.timestamp == 123
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_watch_strategy_decodes_compressed_sse_event(self):
+        """async watch_strategy must frame decoded response bytes, not compressed wire bytes."""
+        import asyncio
+
+        async def _run():
+            body = gzip.compress(
+                b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+                b'"data":{"compressed":true},"timestamp":123}\n\n'
+            )
+
+            class AsyncBytes(httpx.AsyncByteStream):
+                async def __aiter__(self):
+                    yield body
+
+            transport = httpx.MockTransport(
+                lambda request: httpx.Response(
+                    200,
+                    stream=AsyncBytes(),
+                    headers={
+                        "content-type": "text/event-stream",
+                        "content-encoding": "gzip",
+                    },
+                )
+            )
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._client = httpx.AsyncClient(
+                base_url="https://api.polyforge.io",
+                headers={"Authorization": "Bearer test-key"},
+                transport=transport,
+            )
+            event = await anext(client.watch_strategy("strat-1"))
+            assert event.type == "CONNECTED"
+            assert event.strategy_id == "strat-1"
+            assert event.data == {"compressed": True}
             assert event.timestamp == 123
             await client.close()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6149,6 +6149,11 @@ class TestSseStreamTimeout:
             "",
         ]
 
+    def test_sync_sse_reader_keeps_lf_after_mid_chunk_cr(self):
+        """A CR delimiter must not consume a later chunk's real LF delimiter."""
+        lines = list(_iter_sse_lines(iter([b"data: one\rdata: two", b"\n\n"])))
+        assert lines == ["data: one", "data: two", ""]
+
     def test_async_watch_strategy_rejects_overlong_sse_line(self):
         """async watch_strategy must not buffer an unterminated SSE line indefinitely."""
         import asyncio
@@ -6241,6 +6246,22 @@ class TestSseStreamTimeout:
                 'data: {"type":"CONNECTED","strategyId":"strat-1","data":{"cr":true},"timestamp":123}',
                 "",
             ]
+
+        asyncio.run(_run())
+
+    def test_async_sse_reader_keeps_lf_after_mid_chunk_cr(self):
+        """A CR delimiter must not consume a later chunk's real LF delimiter."""
+        import asyncio
+
+        async def chunks():
+            yield b"data: one\rdata: two"
+            yield b"\n\n"
+
+        async def _run():
+            lines = []
+            async for line in _aiter_sse_lines(chunks()):
+                lines.append(line)
+            assert lines == ["data: one", "data: two", ""]
 
         asyncio.run(_run())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 from polyforge.client import (
     PolyforgeClient,
     AsyncPolyforgeClient,
+    _MAX_SSE_LINE_BYTES,
     _parse,
     _parse_pagination,
     _raise_for_status,
@@ -6049,6 +6050,118 @@ class TestSseStreamTimeout:
         source = inspect.getsource(AsyncPolyforgeClient.watch_strategy)
         assert "self._stream_timeout" in source
         assert "httpx.Timeout" in source
+
+    def test_sync_watch_strategy_rejects_overlong_sse_line(self):
+        """watch_strategy must not buffer an unterminated SSE line indefinitely."""
+        overlong = b"data: " + (b"x" * _MAX_SSE_LINE_BYTES)
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                stream=httpx.ByteStream(overlong),
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+        client = PolyforgeClient(api_key="test-key")
+        client._client = httpx.Client(
+            base_url="https://api.polyforge.io",
+            headers={"Authorization": "Bearer test-key"},
+            transport=transport,
+        )
+        with pytest.raises(PolyforgeError, match="SSE event line exceeded"):
+            next(client.watch_strategy("strat-1"))
+        client.close()
+
+    def test_sync_watch_strategy_yields_valid_sse_event(self):
+        """watch_strategy still parses normal SSE data lines."""
+        body = (
+            b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+            b'"data":{"ok":true},"timestamp":123}\n\n'
+        )
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                stream=httpx.ByteStream(body),
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+        client = PolyforgeClient(api_key="test-key")
+        client._client = httpx.Client(
+            base_url="https://api.polyforge.io",
+            headers={"Authorization": "Bearer test-key"},
+            transport=transport,
+        )
+        event = next(client.watch_strategy("strat-1"))
+        assert event.type == "CONNECTED"
+        assert event.strategy_id == "strat-1"
+        assert event.data == {"ok": True}
+        assert event.timestamp == 123
+        client.close()
+
+    def test_async_watch_strategy_rejects_overlong_sse_line(self):
+        """async watch_strategy must not buffer an unterminated SSE line indefinitely."""
+        import asyncio
+
+        async def _run():
+            overlong = b"data: " + (b"x" * _MAX_SSE_LINE_BYTES)
+
+            class AsyncBytes(httpx.AsyncByteStream):
+                async def __aiter__(self):
+                    yield overlong
+
+            transport = httpx.MockTransport(
+                lambda request: httpx.Response(
+                    200,
+                    stream=AsyncBytes(),
+                    headers={"content-type": "text/event-stream"},
+                )
+            )
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._client = httpx.AsyncClient(
+                base_url="https://api.polyforge.io",
+                headers={"Authorization": "Bearer test-key"},
+                transport=transport,
+            )
+            with pytest.raises(PolyforgeError, match="SSE event line exceeded"):
+                await anext(client.watch_strategy("strat-1"))
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_watch_strategy_yields_valid_sse_event(self):
+        """async watch_strategy still parses normal SSE data lines."""
+        import asyncio
+
+        async def _run():
+            body = (
+                b'data: {"type":"CONNECTED","strategyId":"strat-1",'
+                b'"data":{"ok":true},"timestamp":123}\n\n'
+            )
+
+            class AsyncBytes(httpx.AsyncByteStream):
+                async def __aiter__(self):
+                    yield body
+
+            transport = httpx.MockTransport(
+                lambda request: httpx.Response(
+                    200,
+                    stream=AsyncBytes(),
+                    headers={"content-type": "text/event-stream"},
+                )
+            )
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._client = httpx.AsyncClient(
+                base_url="https://api.polyforge.io",
+                headers={"Authorization": "Bearer test-key"},
+                transport=transport,
+            )
+            event = await anext(client.watch_strategy("strat-1"))
+            assert event.type == "CONNECTED"
+            assert event.strategy_id == "strat-1"
+            assert event.data == {"ok": True}
+            assert event.timestamp == 123
+            await client.close()
+
+        asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace httpx `iter_lines()` / `aiter_lines()` in `watch_strategy()` with bounded raw-byte SSE line readers.
- Cap individual SSE lines at 64 KiB and raise `PolyforgeError(code="SSE_LINE_TOO_LONG")` before an unterminated stream can grow memory without bound.
- Add sync and async regressions for overlong unterminated lines plus normal event parsing.

Closes #284

## Verification
- `PYTHONPATH=src /home/f4cte/polyforge-sdk-python/.venv/bin/python -m pytest tests/test_client.py::TestSseStreamTimeout -q`
- `PYTHONPATH=src /home/f4cte/polyforge-sdk-python/.venv/bin/python -m pytest tests/test_client.py -q`
- `PYTHONPATH=src /home/f4cte/polyforge-sdk-python/.venv/bin/python -m compileall -q src tests`
- `git diff --check`
- `npx gitnexus impact -r POLA-8904-watch-strategy-sse --direction upstream --include-tests "Method:src/polyforge/client.py:PolyforgeClient.watch_strategy#1"` -> LOW, 0 direct callers, 0 affected processes
- `npx gitnexus impact -r POLA-8904-watch-strategy-sse --direction upstream --include-tests "Method:src/polyforge/client.py:AsyncPolyforgeClient.watch_strategy#1"` -> LOW, 0 direct callers, 0 affected processes
- `npx gitnexus detect-changes -r POLA-8904-watch-strategy-sse --scope all` -> low risk, 0 affected processes
