### PR TITLE
fix(sdk-python): serialize conditional limitPrice as string

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2744,7 +2744,7 @@ class PolyforgeClient:
         }
         if limit_price is not None:
             _validate_financial_param("limit_price", limit_price)
-            body["limitPrice"] = limit_price
+            body["limitPrice"] = str(limit_price)
         return _parse(
             ConditionalOrder,
             self._post(
@@ -5976,7 +5976,7 @@ class AsyncPolyforgeClient:
         }
         if limit_price is not None:
             _validate_financial_param("limit_price", limit_price)
-            body["limitPrice"] = limit_price
+            body["limitPrice"] = str(limit_price)
         return _parse(
             ConditionalOrder,
             await self._post(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2590,9 +2590,77 @@ class TestConditionalOrders:
         source = inspect.getsource(PolyforgeClient.create_conditional_order)
         assert "_validate_financial_param" in source
 
+    def test_sync_create_conditional_order_sends_limit_price_as_string(self):
+        """create_conditional_order() must send limitPrice as a number string."""
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test-key")
+        client._post = MagicMock(return_value={
+            "id": "co-1",
+            "marketId": "m-1",
+            "tokenId": "tok",
+            "type": "STOP_LOSS",
+            "side": "SELL",
+            "outcome": "YES",
+            "size": "1",
+            "triggerPrice": "0.4",
+            "limitPrice": "0.45",
+            "status": "PENDING",
+        })
+
+        client.create_conditional_order(
+            "m-1",
+            "tok",
+            "STOP_LOSS",
+            "SELL",
+            "YES",
+            1.0,
+            0.4,
+            limit_price=0.45,
+        )
+
+        assert client._post.call_args.kwargs["json"]["limitPrice"] == "0.45"
+        client.close()
+
     def test_async_create_conditional_order_exists(self):
         """AsyncPolyforgeClient must have create_conditional_order."""
         assert hasattr(AsyncPolyforgeClient, "create_conditional_order")
+
+    def test_async_create_conditional_order_sends_limit_price_as_string(self):
+        """Async create_conditional_order() must send limitPrice as a number string."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._post = AsyncMock(return_value={
+                "id": "co-1",
+                "marketId": "m-1",
+                "tokenId": "tok",
+                "type": "STOP_LOSS",
+                "side": "SELL",
+                "outcome": "YES",
+                "size": "1",
+                "triggerPrice": "0.4",
+                "limitPrice": "0.45",
+                "status": "PENDING",
+            })
+
+            await client.create_conditional_order(
+                "m-1",
+                "tok",
+                "STOP_LOSS",
+                "SELL",
+                "YES",
+                1.0,
+                0.4,
+                limit_price=0.45,
+            )
+
+            assert client._post.call_args.kwargs["json"]["limitPrice"] == "0.45"
+            await client.close()
+
+        asyncio.run(_run())
 
     # -- get_conditional_order --
 


### PR DESCRIPTION
## Summary
- Serialize `create_conditional_order(..., limit_price=...)` as string `limitPrice` in sync and async clients
- Add sync and async regression coverage for the outgoing conditional-order JSON payload

## Test Plan
- `PYTHONPATH=src /home/f4cte/polyforge-sdk-python/.venv/bin/python -m pytest tests/test_client.py -k "conditional_order"`

Closes #293