### PR TITLE
fix(sdk-python): support conditional order trailing pct expiry

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -2791,6 +2791,8 @@ class PolyforgeClient:
         trigger_price: float,
         *,
         limit_price: float | None = None,
+        trailing_pct: float | None = None,
+        expires_at: str | None = None,
         idempotency_key: str | None = None,
     ) -> ConditionalOrder:
         """Create a conditional order.
@@ -2804,6 +2806,8 @@ class PolyforgeClient:
             size: Order size.
             trigger_price: Price at which the order triggers.
             limit_price: Optional limit price for the triggered order.
+            trailing_pct: Optional trailing percentage for ``"TRAILING_STOP"`` orders.
+            expires_at: Optional ISO 8601 expiry timestamp.
 
         Returns:
             The created :class:`ConditionalOrder`.
@@ -2822,6 +2826,11 @@ class PolyforgeClient:
         if limit_price is not None:
             _validate_financial_param("limit_price", limit_price)
             body["limitPrice"] = str(limit_price)
+        if trailing_pct is not None:
+            _validate_financial_param("trailing_pct", trailing_pct)
+            body["trailingPct"] = str(trailing_pct)
+        if expires_at is not None:
+            body["expiresAt"] = expires_at
         return _parse(
             ConditionalOrder,
             self._post(
@@ -6199,6 +6208,8 @@ class AsyncPolyforgeClient:
         trigger_price: float,
         *,
         limit_price: float | None = None,
+        trailing_pct: float | None = None,
+        expires_at: str | None = None,
         idempotency_key: str | None = None,
     ) -> ConditionalOrder:
         """Create a conditional order.
@@ -6212,6 +6223,8 @@ class AsyncPolyforgeClient:
             size: Order size.
             trigger_price: Price at which the order triggers.
             limit_price: Optional limit price for the triggered order.
+            trailing_pct: Optional trailing percentage for ``"TRAILING_STOP"`` orders.
+            expires_at: Optional ISO 8601 expiry timestamp.
 
         Returns:
             The created :class:`ConditionalOrder`.
@@ -6230,6 +6243,11 @@ class AsyncPolyforgeClient:
         if limit_price is not None:
             _validate_financial_param("limit_price", limit_price)
             body["limitPrice"] = str(limit_price)
+        if trailing_pct is not None:
+            _validate_financial_param("trailing_pct", trailing_pct)
+            body["trailingPct"] = str(trailing_pct)
+        if expires_at is not None:
+            body["expiresAt"] = expires_at
         return _parse(
             ConditionalOrder,
             await self._post(

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -1059,6 +1059,8 @@ class ConditionalOrder:
     size: str = ""
     trigger_price: str = ""
     limit_price: str | None = None
+    trailing_pct: str | None = None
+    expires_at: str | None = None
     status: str = ""
     triggered_at: str | None = None
     created_at: str = ""

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -1059,12 +1059,12 @@ class ConditionalOrder:
     size: str = ""
     trigger_price: str = ""
     limit_price: str | None = None
-    trailing_pct: str | None = None
-    expires_at: str | None = None
     status: str = ""
     triggered_at: str | None = None
     created_at: str = ""
     updated_at: str = ""
+    trailing_pct: str | None = None
+    expires_at: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2697,6 +2697,32 @@ class TestAlertCrud:
         assert order.expires_at == "2026-06-01T12:00:00Z"
         assert order.limit_price is None
 
+    def test_conditional_order_preserves_positional_field_order(self):
+        """Existing positional construction must keep status and timestamps aligned."""
+        order = ConditionalOrder(
+            "co-1",
+            "m-1",
+            "t-1",
+            "STOP_LOSS",
+            "SELL",
+            "YES",
+            "10",
+            "0.50",
+            "0.45",
+            "PENDING",
+            "2026-05-31T12:00:00Z",
+            "2026-05-31T11:00:00Z",
+            "2026-05-31T11:30:00Z",
+        )
+
+        assert order.limit_price == "0.45"
+        assert order.status == "PENDING"
+        assert order.triggered_at == "2026-05-31T12:00:00Z"
+        assert order.created_at == "2026-05-31T11:00:00Z"
+        assert order.updated_at == "2026-05-31T11:30:00Z"
+        assert order.trailing_pct is None
+        assert order.expires_at is None
+
     def test_conditional_order_defaults(self):
         """ConditionalOrder defaults should be sensible."""
         order = ConditionalOrder()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2686,11 +2686,15 @@ class TestAlertCrud:
             outcome="YES",
             size="10",
             trigger_price="0.50",
+            trailing_pct="0.05",
+            expires_at="2026-06-01T12:00:00Z",
             status="PENDING",
         )
         assert order.id == "co-1"
         assert order.market_id == "m-1"
         assert order.trigger_price == "0.50"
+        assert order.trailing_pct == "0.05"
+        assert order.expires_at == "2026-06-01T12:00:00Z"
         assert order.limit_price is None
 
     def test_conditional_order_defaults(self):
@@ -2700,6 +2704,8 @@ class TestAlertCrud:
         assert order.status == ""
         assert order.triggered_at is None
         assert order.limit_price is None
+        assert order.trailing_pct is None
+        assert order.expires_at is None
 
     def test_portfolio_pnl_model_fields(self):
         """PortfolioPnl must have all expected fields."""
@@ -2878,6 +2884,37 @@ class TestConditionalOrders:
         for name in ("market_id", "token_id", "type", "side", "outcome", "size", "trigger_price"):
             assert name in param_names, f"Missing param: {name}"
         assert "limit_price" in param_names
+        assert "trailing_pct" in param_names
+        assert "expires_at" in param_names
+
+    def test_sync_create_conditional_order_sends_trailing_pct_and_expires_at(self):
+        """create_conditional_order() must serialize trailing stop and expiry fields."""
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test-key")
+        client._post = MagicMock(return_value={
+            "id": "co-1",
+            "trailingPct": "0.05",
+            "expiresAt": "2026-06-01T12:00:00Z",
+        })
+
+        order = client.create_conditional_order(
+            "m-1",
+            "tok",
+            "TRAILING_STOP",
+            "SELL",
+            "YES",
+            1.0,
+            0.4,
+            trailing_pct=0.05,
+            expires_at="2026-06-01T12:00:00Z",
+        )
+
+        assert client._post.call_args.kwargs["json"]["trailingPct"] == "0.05"
+        assert client._post.call_args.kwargs["json"]["expiresAt"] == "2026-06-01T12:00:00Z"
+        assert order.trailing_pct == "0.05"
+        assert order.expires_at == "2026-06-01T12:00:00Z"
+        client.close()
 
     def test_sync_create_conditional_order_path(self):
         """create_conditional_order() must POST to /api/v1/orders/conditional."""
@@ -2962,6 +2999,39 @@ class TestConditionalOrders:
             )
 
             assert client._post.call_args.kwargs["json"]["limitPrice"] == "0.45"
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_create_conditional_order_sends_trailing_pct_and_expires_at(self):
+        """Async create_conditional_order() must serialize trailing stop and expiry fields."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test-key")
+            client._post = AsyncMock(return_value={
+                "id": "co-1",
+                "trailingPct": "0.05",
+                "expiresAt": "2026-06-01T12:00:00Z",
+            })
+
+            order = await client.create_conditional_order(
+                "m-1",
+                "tok",
+                "TRAILING_STOP",
+                "SELL",
+                "YES",
+                1.0,
+                0.4,
+                trailing_pct=0.05,
+                expires_at="2026-06-01T12:00:00Z",
+            )
+
+            assert client._post.call_args.kwargs["json"]["trailingPct"] == "0.05"
+            assert client._post.call_args.kwargs["json"]["expiresAt"] == "2026-06-01T12:00:00Z"
+            assert order.trailing_pct == "0.05"
+            assert order.expires_at == "2026-06-01T12:00:00Z"
             await client.close()
 
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add sync/async create_conditional_order support for trailing_pct and expires_at
- serialize trailing_pct as platform-compatible number string trailingPct
- parse trailingPct/expiresAt on ConditionalOrder responses
- add regression coverage for request payloads and response model fields

## Verification
- uv run --with pytest --with pytest-asyncio python -m pytest -q -> 1003 passed, 1 warning
- git diff --check -> clean
- GitNexus impact: create_conditional_order LOW; ConditionalOrder MEDIUM, no HIGH/CRITICAL risk
- Argus post-fix review: POLA-9749 approved

Closes #294