### PR TITLE
fix(sdk-python): vote_market_sentiment accepts direction YES/NO and confidence 1-100

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -458,7 +458,6 @@ _VALID_ORDER_MOODS = frozenset(
     {"CONFIDENT", "UNCERTAIN", "FOMO", "DISCIPLINED", "REVENGE"}
 )
 _VALID_COMBO_LEG_OUTCOMES = frozenset({"yes", "no"})
-_VALID_SENTIMENT_DIRECTIONS = frozenset({"BUY", "SELL"})
 
 
 def _validate_financial_param(name: str, value: float) -> None:

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -442,6 +442,7 @@ def _validate_enum(name: str, value: str, allowed: frozenset[str]) -> None:
 
 _VALID_MODES = frozenset({"live", "paper"})
 _VALID_SIDES = frozenset({"BUY", "SELL"})
+_VALID_SENTIMENT_DIRECTIONS = frozenset({"YES", "NO"})
 _VALID_OUTCOMES = frozenset({"YES", "NO"})
 _VALID_ORDER_TYPES = frozenset({"GTC", "GTD", "FOK", "FAK", "POST_ONLY"})
 _VALID_SMART_ORDER_TYPES = frozenset({"TWAP", "DCA", "BRACKET", "OCO"})
@@ -4239,8 +4240,8 @@ class PolyforgeClient:
         self,
         market_id: str,
         *,
-        direction: str,
-        confidence: float,
+        direction: str = "YES",
+        confidence: int = 50,
     ) -> MarketSentimentReport:
         """Submit (or refresh) the current user's sentiment for a market.
 
@@ -4248,30 +4249,28 @@ class PolyforgeClient:
         currently returns the same payload shape as the GET variant.
 
         Args:
-            market_id: The market to vote on.
-            direction: ``BUY`` or ``SELL``.
-            confidence: Confidence level (0-100).
+            market_id: The market id to vote on.
+            direction: ``"YES"`` or ``"NO"``. Defaults to ``"YES"``.
+            confidence: Integer confidence in ``[1, 100]``. Defaults to ``50``.
+
+        Raises:
+            ValueError: if direction is not ``"YES"`` or ``"NO"``, or
+                confidence is not an integer in ``[1, 100]``.
         """
         _validate_enum("direction", direction, _VALID_SENTIMENT_DIRECTIONS)
-        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
-            raise TypeError(
-                f"confidence must be a number, got {type(confidence).__name__}"
+        if not isinstance(confidence, int) or isinstance(confidence, bool):
+            raise ValueError(
+                f"confidence must be an integer in [1, 100], got {confidence!r}"
             )
-        if isinstance(confidence, float):
-            if math.isnan(confidence):
-                raise ValueError("confidence must not be NaN")
-            if math.isinf(confidence):
-                raise ValueError("confidence must not be Infinity")
-        if confidence < 0:
-            raise ValueError(f"confidence must be non-negative, got {confidence}")
-        if confidence > 100:
-            raise ValueError(f"confidence must not exceed 100, got {confidence}")
-        body: dict[str, Any] = {"direction": direction, "confidence": confidence}
+        if confidence < 1 or confidence > 100:
+            raise ValueError(
+                f"confidence must be an integer in [1, 100], got {confidence}"
+            )
         return _parse(
             MarketSentimentReport,
             self._post(
                 f"/api/v1/markets/{_encode_path(market_id)}/sentiment",
-                json=body,
+                json={"direction": direction, "confidence": confidence},
             ),
         )
 
@@ -7413,30 +7412,34 @@ class AsyncPolyforgeClient:
         self,
         market_id: str,
         *,
-        direction: str,
-        confidence: float,
+        direction: str = "YES",
+        confidence: int = 50,
     ) -> MarketSentimentReport:
-        """Async variant of :meth:`PolyforgeClient.vote_market_sentiment`."""
+        """Async variant of :meth:`PolyforgeClient.vote_market_sentiment`.
+
+        Args:
+            market_id: The market id to vote on.
+            direction: ``"YES"`` or ``"NO"``. Defaults to ``"YES"``.
+            confidence: Integer confidence in ``[1, 100]``. Defaults to ``50``.
+
+        Raises:
+            ValueError: if direction is not ``"YES"`` or ``"NO"``, or
+                confidence is not an integer in ``[1, 100]``.
+        """
         _validate_enum("direction", direction, _VALID_SENTIMENT_DIRECTIONS)
-        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
-            raise TypeError(
-                f"confidence must be a number, got {type(confidence).__name__}"
+        if not isinstance(confidence, int) or isinstance(confidence, bool):
+            raise ValueError(
+                f"confidence must be an integer in [1, 100], got {confidence!r}"
             )
-        if isinstance(confidence, float):
-            if math.isnan(confidence):
-                raise ValueError("confidence must not be NaN")
-            if math.isinf(confidence):
-                raise ValueError("confidence must not be Infinity")
-        if confidence < 0:
-            raise ValueError(f"confidence must be non-negative, got {confidence}")
-        if confidence > 100:
-            raise ValueError(f"confidence must not exceed 100, got {confidence}")
-        body: dict[str, Any] = {"direction": direction, "confidence": confidence}
+        if confidence < 1 or confidence > 100:
+            raise ValueError(
+                f"confidence must be an integer in [1, 100], got {confidence}"
+            )
         return _parse(
             MarketSentimentReport,
             await self._post(
                 f"/api/v1/markets/{_encode_path(market_id)}/sentiment",
-                json=body,
+                json={"direction": direction, "confidence": confidence},
             ),
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10674,3 +10674,242 @@ class TestRootExports:
         assert not missing, (
             f"Names in __all__ but not accessible as polyforge.<name>: {', '.join(missing)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# ── vote_market_sentiment: direction, confidence, and request body ──────────
+
+_sentiment_response = {
+    "data": {
+        "marketId": "m1",
+        "direction": "YES",
+        "confidence": 50,
+        "votedAt": "2026-06-11T12:00:00Z",
+    }
+}
+
+
+class TestVoteMarketSentimentValidation:
+    """Direction and confidence validation for vote_market_sentiment."""
+
+    def _client_with(self, handler):
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    def test_rejects_invalid_direction(self):
+        client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
+        try:
+            with pytest.raises(ValueError, match="direction"):
+                client.vote_market_sentiment("m1", direction="BUY")
+            with pytest.raises(ValueError, match="direction"):
+                client.vote_market_sentiment("m1", direction="SELL")
+            with pytest.raises(ValueError, match="direction"):
+                client.vote_market_sentiment("m1", direction="BULLISH")
+        finally:
+            client.close()
+
+    def test_accepts_yes_direction(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", direction="YES")
+            assert captured["body"]["direction"] == "YES"
+        finally:
+            client.close()
+
+    def test_accepts_no_direction(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", direction="NO")
+            assert captured["body"]["direction"] == "NO"
+        finally:
+            client.close()
+
+    def test_rejects_out_of_range_confidence_low(self):
+        client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
+        try:
+            with pytest.raises(ValueError, match="confidence"):
+                client.vote_market_sentiment("m1", confidence=0)
+        finally:
+            client.close()
+
+    def test_rejects_out_of_range_confidence_high(self):
+        client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
+        try:
+            with pytest.raises(ValueError, match="confidence"):
+                client.vote_market_sentiment("m1", confidence=101)
+        finally:
+            client.close()
+
+    def test_rejects_float_confidence(self):
+        client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
+        try:
+            with pytest.raises(ValueError, match="confidence"):
+                client.vote_market_sentiment("m1", confidence=50.5)
+        finally:
+            client.close()
+
+    def test_rejects_bool_confidence(self):
+        client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
+        try:
+            with pytest.raises(ValueError, match="confidence"):
+                client.vote_market_sentiment("m1", confidence=True)
+            with pytest.raises(ValueError, match="confidence"):
+                client.vote_market_sentiment("m1", confidence=False)
+        finally:
+            client.close()
+
+    def test_accepts_boundary_confidence_1(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", confidence=1)
+            assert captured["body"]["confidence"] == 1
+        finally:
+            client.close()
+
+    def test_accepts_boundary_confidence_100(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", confidence=100)
+            assert captured["body"]["confidence"] == 100
+        finally:
+            client.close()
+
+
+class TestVoteMarketSentimentRequestPayload:
+    """Verify vote_market_sentiment sends direction/confidence JSON body."""
+
+    def _client_with(self, handler):
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    @staticmethod
+    def _async_client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = AsyncPolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.AsyncClient(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    def test_default_direction_and_confidence(self):
+        """vote_market_sentiment sends direction=YES, confidence=50 by default."""
+        captured = {}
+
+        def handler(request):
+            captured["method"] = request.method
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1")
+            assert captured["method"] == "POST"
+            assert captured["body"] == {"direction": "YES", "confidence": 50}
+        finally:
+            client.close()
+
+    def test_custom_direction_and_confidence(self):
+        """vote_market_sentiment sends the provided direction and confidence."""
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", direction="NO", confidence=75)
+            assert captured["body"] == {"direction": "NO", "confidence": 75}
+        finally:
+            client.close()
+
+    def test_confidence_boundaries_in_payload(self):
+        """Boundary confidence values are included in the request body."""
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._client_with(handler)
+        try:
+            client.vote_market_sentiment("m1", confidence=1)
+            assert captured["body"]["confidence"] == 1
+
+            captured["body"] = None
+            client.vote_market_sentiment("m1", confidence=100)
+            assert captured["body"]["confidence"] == 100
+        finally:
+            client.close()
+
+    def test_async_vote_market_sentiment_sends_body(self):
+        """AsyncPolyforgeClient.vote_market_sentiment sends direction/confidence JSON body."""
+        captured = {}
+
+        async def handler(request):
+            captured["method"] = request.method
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._async_client_with(handler)
+        try:
+            import asyncio
+            asyncio.run(client.vote_market_sentiment("m1"))
+            assert captured["method"] == "POST"
+            assert captured["body"] == {"direction": "YES", "confidence": 50}
+        finally:
+            client.close()
+
+    def test_async_vote_market_sentiment_custom_values(self):
+        """AsyncPolyforgeClient.vote_market_sentiment sends custom direction/confidence."""
+        captured = {}
+
+        async def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=_sentiment_response)
+
+        client = self._async_client_with(handler)
+        try:
+            import asyncio
+            asyncio.run(client.vote_market_sentiment("m1", direction="NO", confidence=80))
+            assert captured["body"] == {"direction": "NO", "confidence": 80}
+        finally:
+            client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8353,7 +8353,7 @@ class TestMiscUtilityEnumValidation:
         try:
             with pytest.raises(ValueError, match="direction"):
                 client.vote_market_sentiment(
-                    "m1", direction="HOLD", confidence=50,
+                    "m1", direction="BUY", confidence=50,
                 )
         finally:
             client.close()
@@ -8361,39 +8361,29 @@ class TestMiscUtilityEnumValidation:
     def test_vote_market_sentiment_rejects_bool_confidence(self):
         client = PolyforgeClient(api_key="test")
         try:
-            with pytest.raises(TypeError, match="number"):
+            with pytest.raises(ValueError, match="confidence"):
                 client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=True,
+                    "m1", direction="YES", confidence=True,
                 )
         finally:
             client.close()
 
-    def test_vote_market_sentiment_rejects_nan_confidence(self):
+    def test_vote_market_sentiment_rejects_float_confidence(self):
         client = PolyforgeClient(api_key="test")
         try:
-            with pytest.raises(ValueError, match="NaN"):
+            with pytest.raises(ValueError, match="confidence"):
                 client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=float("nan"),
+                    "m1", direction="YES", confidence=50.5,
                 )
         finally:
             client.close()
 
-    def test_vote_market_sentiment_rejects_inf_confidence(self):
+    def test_vote_market_sentiment_rejects_zero_confidence(self):
         client = PolyforgeClient(api_key="test")
         try:
-            with pytest.raises(ValueError, match="Infinity"):
+            with pytest.raises(ValueError, match="confidence"):
                 client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=float("inf"),
-                )
-        finally:
-            client.close()
-
-    def test_vote_market_sentiment_rejects_negative_confidence(self):
-        client = PolyforgeClient(api_key="test")
-        try:
-            with pytest.raises(ValueError, match="non-negative"):
-                client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=-1,
+                    "m1", direction="YES", confidence=0,
                 )
         finally:
             client.close()
@@ -8401,21 +8391,9 @@ class TestMiscUtilityEnumValidation:
     def test_vote_market_sentiment_rejects_confidence_above_100(self):
         client = PolyforgeClient(api_key="test")
         try:
-            with pytest.raises(ValueError, match="exceed 100"):
+            with pytest.raises(ValueError, match="confidence"):
                 client.vote_market_sentiment(
-                    "m1", direction="SELL", confidence=101,
-                )
-        finally:
-            client.close()
-
-    def test_vote_market_sentiment_rejects_huge_int_confidence(self):
-        """math.isnan/isinf on huge ints raises OverflowError — range check
-        must fire first to avoid a low-level exception."""
-        client = PolyforgeClient(api_key="test")
-        try:
-            with pytest.raises(ValueError, match="exceed 100"):
-                client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=10**400,
+                    "m1", direction="NO", confidence=101,
                 )
         finally:
             client.close()
@@ -8749,20 +8727,20 @@ class TestMiscUtilityEndpointRoundtrips:
                 captured["body"] = request.content
             return httpx.Response(200, json={
                 "yesPercent": 60, "noPercent": 40, "totalVotes": 5,
-                "userVote": {"direction": "BUY", "confidence": 85},
+                "userVote": {"direction": "YES", "confidence": 85},
             })
         client = self._client_with(handler)
         try:
             report = client.get_market_sentiment_report("m1")
             assert captured["method"] == "GET"
             assert report.user_vote is not None
-            assert report.user_vote.direction == "BUY"
+            assert report.user_vote.direction == "YES"
 
             voted = client.vote_market_sentiment(
-                "m1", direction="BUY", confidence=85,
+                "m1", direction="YES", confidence=85,
             )
             assert captured["method"] == "POST"
-            assert captured["body"] == {"direction": "BUY", "confidence": 85}
+            assert captured["body"] == {"direction": "YES", "confidence": 85}
             assert voted.total_votes == 5
             assert voted.user_vote is not None
             assert voted.user_vote.confidence == 85
@@ -8781,7 +8759,7 @@ class TestMiscUtilityEndpointRoundtrips:
                 captured["body"] = json.loads(request.content)
                 return httpx.Response(200, json={
                     "yesPercent": 60, "noPercent": 40, "totalVotes": 5,
-                    "userVote": {"direction": "BUY", "confidence": 0.8},
+                    "userVote": {"direction": "YES", "confidence": 50},
                 })
 
         async def _run():
@@ -8792,10 +8770,10 @@ class TestMiscUtilityEndpointRoundtrips:
                     transport=_AsyncCaptureTransport(),
                 )
                 report = await client.vote_market_sentiment(
-                    "m1", direction="SELL", confidence=50,
+                    "m1", direction="NO", confidence=50,
                 )
                 assert captured["method"] == "POST"
-                assert captured["body"] == {"direction": "SELL", "confidence": 50}
+                assert captured["body"] == {"direction": "NO", "confidence": 50}
                 assert report.total_votes == 5
 
         asyncio.run(_run())
@@ -9094,17 +9072,17 @@ class TestMiscUtilityEndpointsAsync:
                 captured["body"] = json.loads(request.content)
             return httpx.Response(200, json={
                 "yesPercent": 60, "noPercent": 40, "totalVotes": 5,
-                "userVote": {"direction": "BUY", "confidence": 0.8},
+                "userVote": {"direction": "YES", "confidence": 80},
             })
 
         async def _run():
             client = self._async_client_with(handler)
             try:
                 voted = await client.vote_market_sentiment(
-                    "m1", direction="BUY", confidence=80,
+                    "m1", direction="YES", confidence=80,
                 )
                 assert captured["method"] == "POST"
-                assert captured["body"] == {"direction": "BUY", "confidence": 80}
+                assert captured["body"] == {"direction": "YES", "confidence": 80}
                 assert voted.total_votes == 5
             finally:
                 await client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8373,7 +8373,7 @@ class TestMiscUtilityEnumValidation:
         try:
             with pytest.raises(ValueError, match="confidence"):
                 client.vote_market_sentiment(
-                    "m1", direction="YES", confidence=50.5,
+                    "m1", direction="YES", confidence=50.5,  # type: ignore[reportArgumentType]
                 )
         finally:
             client.close()
@@ -10740,7 +10740,7 @@ class TestVoteMarketSentimentValidation:
         client = self._client_with(lambda req: httpx.Response(200, json=_sentiment_response))
         try:
             with pytest.raises(ValueError, match="confidence"):
-                client.vote_market_sentiment("m1", confidence=50.5)
+                client.vote_market_sentiment("m1", confidence=50.5)  # type: ignore[reportArgumentType]
         finally:
             client.close()
 
@@ -10852,7 +10852,6 @@ class TestVoteMarketSentimentRequestPayload:
             client.vote_market_sentiment("m1", confidence=1)
             assert captured["body"]["confidence"] == 1
 
-            captured["body"] = None
             client.vote_market_sentiment("m1", confidence=100)
             assert captured["body"]["confidence"] == 100
         finally:
@@ -10867,14 +10866,17 @@ class TestVoteMarketSentimentRequestPayload:
             captured["body"] = json.loads(request.content)
             return httpx.Response(200, json=_sentiment_response)
 
-        client = self._async_client_with(handler)
-        try:
-            import asyncio
-            asyncio.run(client.vote_market_sentiment("m1"))
-            assert captured["method"] == "POST"
-            assert captured["body"] == {"direction": "YES", "confidence": 50}
-        finally:
-            client.close()
+        async def _run():
+            client = self._async_client_with(handler)
+            try:
+                await client.vote_market_sentiment("m1")
+                assert captured["method"] == "POST"
+                assert captured["body"] == {"direction": "YES", "confidence": 50}
+            finally:
+                await client.close()
+
+        import asyncio
+        asyncio.run(_run())
 
     def test_async_vote_market_sentiment_custom_values(self):
         """AsyncPolyforgeClient.vote_market_sentiment sends custom direction/confidence."""
@@ -10884,10 +10886,13 @@ class TestVoteMarketSentimentRequestPayload:
             captured["body"] = json.loads(request.content)
             return httpx.Response(200, json=_sentiment_response)
 
-        client = self._async_client_with(handler)
-        try:
-            import asyncio
-            asyncio.run(client.vote_market_sentiment("m1", direction="NO", confidence=80))
-            assert captured["body"] == {"direction": "NO", "confidence": 80}
-        finally:
-            client.close()
+        async def _run():
+            client = self._async_client_with(handler)
+            try:
+                await client.vote_market_sentiment("m1", direction="NO", confidence=80)
+                assert captured["body"] == {"direction": "NO", "confidence": 80}
+            finally:
+                await client.close()
+
+        import asyncio
+        asyncio.run(_run())


### PR DESCRIPTION
Fixes POLA-11009: vote_market_sentiment now accepts direction (YES/NO) and confidence (1-100) parameters matching platform DTO. Both sync and async variants updated with validation and tests.

Replaces closed PR #306 (branch force-pushed, state locked).