### PR TITLE
feat(sdk-python): add WebSocket realtime client for /ws gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ asyncio.run(main())
 
 **Common event types:** `CONNECTED` · `STRATEGY_STARTED` · `STRATEGY_STOPPED` · `STRATEGY_PAUSED` · `STRATEGY_RESUMED` · `STRATEGY_ERROR` · `ORDER_SUBMITTED` · `ORDER_PLACED` · `ORDER_PARTIAL` · `ORDER_FILLED` · `ORDER_FAILED` · `ORDER_ERROR` · `ORDER_CANCELLED` · `BACKTEST_PROGRESS` · `BACKTEST_COMPLETED` · `BACKTEST_FAILED`
 
+### WebSocket Gateway
+
+Use `PolyforgeWebSocketClient` for the native `/ws` gateway when you need price ticks, whale trades, or broadcast notifications.
+
+```python
+from polyforge import PolyforgeWebSocketClient
+
+with PolyforgeWebSocketClient(token="jwt-token") as ws:
+    ws.subscribe_prices(["token-yes", "token-no"])
+    ws.subscribe_whales()
+
+    for event in ws.iter_events():
+        if event.type in ("PRICE_UPDATE", "WHALE_TRADE", "NOTIFICATION"):
+            print(event)
+```
+
+The client sends the token as the gateway's `pf_token` cookie by default. Set `auth_mode="query"` only when you need compatibility with an older gateway client path.
+
 ### Portfolio & Orders
 
 | Method | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27",
+    "websocket-client>=1.8",
 ]
 
 [project.urls]

--- a/src/polyforge/__init__.py
+++ b/src/polyforge/__init__.py
@@ -9,6 +9,13 @@ from polyforge.errors import (
     RateLimitError,
     ServerError,
 )
+from polyforge.websocket import (
+    AsyncPolyforgeWebSocketClient,
+    PolyforgeWebSocketClient,
+    WsEvent,
+    WsPriceUpdate,
+    WsWhaleTrade,
+)
 from polyforge.models import (
     AccuracyLeaderboardEntry,
     ActionDefinition,
@@ -137,6 +144,11 @@ __all__ = [
     # Clients
     "PolyforgeClient",
     "AsyncPolyforgeClient",
+    "PolyforgeWebSocketClient",
+    "AsyncPolyforgeWebSocketClient",
+    "WsEvent",
+    "WsPriceUpdate",
+    "WsWhaleTrade",
     # Errors
     "PolyforgeError",
     "AuthenticationError",

--- a/src/polyforge/websocket.py
+++ b/src/polyforge/websocket.py
@@ -1,0 +1,330 @@
+"""WebSocket client helpers for the Polyforge ``/ws`` gateway."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Any, Literal
+from urllib.parse import urlencode, urlparse, urlunparse
+
+
+WsMessage = dict[str, Any]
+WsAuthMode = Literal["cookie", "query"]
+
+
+@dataclass
+class WsEvent:
+    """A generic server-to-client WebSocket event."""
+
+    type: str
+    data: Any = None
+    timestamp: int | None = None
+    raw: WsMessage | None = None
+
+
+@dataclass
+class WsPriceUpdate(WsEvent):
+    """A token price update from ``SUBSCRIBE_PRICES``."""
+
+    token_id: str = ""
+    price: Any = None
+    type: str = "PRICE_UPDATE"
+
+
+@dataclass
+class WsWhaleTrade(WsEvent):
+    """A whale trade event from ``SUBSCRIBE_WHALES``."""
+
+    type: str = "WHALE_TRADE"
+
+
+def _build_ws_url(api_url: str, token: str | None = None) -> str:
+    """Build the authenticated ``/ws`` gateway URL from the REST API URL."""
+    parsed = urlparse(api_url.rstrip("/"))
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    return urlunparse(
+        (
+            scheme,
+            parsed.netloc,
+            "/ws",
+            "",
+            urlencode({"token": token}) if token else "",
+            "",
+        )
+    )
+
+
+def _create_connection(
+    url: str,
+    *,
+    timeout: float | None = None,
+    header: list[str] | None = None,
+    cookie: str | None = None,
+    origin: str | None = None,
+) -> Any:
+    try:
+        import websocket
+    except ImportError as exc:  # pragma: no cover - exercised only without dependency installed
+        raise RuntimeError(
+            "WebSocket support requires the 'websocket-client' package. "
+            "Install polyforge with its runtime dependencies."
+        ) from exc
+    return websocket.create_connection(
+        url,
+        timeout=timeout,
+        header=header,
+        cookie=cookie,
+        origin=origin,
+    )
+
+
+def _parse_event(message: WsMessage) -> WsEvent:
+    event_type = message["type"]
+    data = message.get("data")
+    timestamp = message.get("timestamp")
+    if not isinstance(timestamp, int):
+        timestamp = None
+
+    if event_type == "PRICE_UPDATE":
+        payload = data if isinstance(data, dict) else message
+        return WsPriceUpdate(
+            data=data,
+            timestamp=timestamp,
+            raw=message,
+            token_id=str(payload.get("tokenId", "")),
+            price=payload.get("price"),
+        )
+    if event_type == "WHALE_TRADE":
+        return WsWhaleTrade(data=data, timestamp=timestamp, raw=message)
+    return WsEvent(type=event_type, data=data, timestamp=timestamp, raw=message)
+
+
+class PolyforgeWebSocketClient:
+    """Synchronous client for the Polyforge native WebSocket gateway.
+
+    The platform gateway authenticates non-browser clients with the
+    ``pf_token`` cookie by default and accepts JSON messages such as
+    ``SUBSCRIBE_PRICES``, ``SUBSCRIBE_WHALES``, and ``PING``.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        api_url: str = "https://api.polyforge.app",
+        timeout: float | None = None,
+        origin: str | None = None,
+        auth_mode: WsAuthMode = "cookie",
+    ) -> None:
+        if not token:
+            raise ValueError("token is required")
+        if auth_mode not in ("cookie", "query"):
+            raise ValueError("auth_mode must be 'cookie' or 'query'")
+        self._token = token
+        self._auth_mode = auth_mode
+        self._url = _build_ws_url(api_url, token if auth_mode == "query" else None)
+        self._timeout = timeout
+        self._origin = origin
+        self._ws: Any | None = None
+        self._price_subscriptions: set[str] = set()
+        self._strategy_subscriptions: set[str] = set()
+        self._whale_subscribed = False
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    def __enter__(self) -> "PolyforgeWebSocketClient":
+        return self.connect()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def connect(self) -> "PolyforgeWebSocketClient":
+        cookie = f"pf_token={self._token}" if self._auth_mode == "cookie" else None
+        self._ws = _create_connection(
+            self._url,
+            timeout=self._timeout,
+            cookie=cookie,
+            origin=self._origin,
+        )
+        self._send_subscription_state()
+        return self
+
+    def reconnect(self) -> "PolyforgeWebSocketClient":
+        self.close()
+        return self.connect()
+
+    def close(self) -> None:
+        if self._ws is not None:
+            self._ws.close()
+            self._ws = None
+
+    def send(self, message: WsMessage) -> None:
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected")
+        self._ws.send(json.dumps(message))
+
+    def receive(self) -> WsMessage:
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected")
+        while True:
+            raw = self._ws.recv()
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            try:
+                message = json.loads(str(raw))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(message, dict) and isinstance(message.get("type"), str):
+                return message
+
+    def iter_messages(self) -> Iterator[WsMessage]:
+        while True:
+            try:
+                yield self.receive()
+            except StopIteration:
+                return
+
+    def receive_event(self) -> WsEvent:
+        return _parse_event(self.receive())
+
+    def iter_events(self) -> Iterator[WsEvent]:
+        for message in self.iter_messages():
+            yield _parse_event(message)
+
+    def subscribe_prices(self, token_ids: list[str]) -> None:
+        self._price_subscriptions.update(token_ids)
+        self.send({"type": "SUBSCRIBE_PRICES", "tokenIds": token_ids})
+
+    def unsubscribe_prices(self, token_ids: list[str]) -> None:
+        for token_id in token_ids:
+            self._price_subscriptions.discard(token_id)
+        self.send({"type": "UNSUBSCRIBE_PRICES", "tokenIds": token_ids})
+
+    def subscribe_whales(self) -> None:
+        self._whale_subscribed = True
+        self.send({"type": "SUBSCRIBE_WHALES"})
+
+    def unsubscribe_whales(self) -> None:
+        self._whale_subscribed = False
+        self.send({"type": "UNSUBSCRIBE_WHALES"})
+
+    def subscribe_strategy(self, strategy_id: str) -> None:
+        self._strategy_subscriptions.add(strategy_id)
+        self.send({"type": "SUBSCRIBE_STRATEGY", "strategyId": strategy_id})
+
+    def unsubscribe_strategy(self, strategy_id: str) -> None:
+        self._strategy_subscriptions.discard(strategy_id)
+        self.send({"type": "UNSUBSCRIBE_STRATEGY", "strategyId": strategy_id})
+
+    def ping(self) -> None:
+        self.send({"type": "PING"})
+
+    def _send_subscription_state(self) -> None:
+        if self._price_subscriptions:
+            self.send({
+                "type": "SUBSCRIBE_PRICES",
+                "tokenIds": sorted(self._price_subscriptions),
+            })
+        for strategy_id in sorted(self._strategy_subscriptions):
+            self.send({"type": "SUBSCRIBE_STRATEGY", "strategyId": strategy_id})
+        if self._whale_subscribed:
+            self.send({"type": "SUBSCRIBE_WHALES"})
+
+
+class AsyncPolyforgeWebSocketClient:
+    """Async wrapper around :class:`PolyforgeWebSocketClient`."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        api_url: str = "https://api.polyforge.app",
+        timeout: float | None = None,
+        origin: str | None = None,
+        auth_mode: WsAuthMode = "cookie",
+    ) -> None:
+        self._client = PolyforgeWebSocketClient(
+            token=token,
+            api_url=api_url,
+            timeout=timeout,
+            origin=origin,
+            auth_mode=auth_mode,
+        )
+
+    @property
+    def url(self) -> str:
+        return self._client.url
+
+    async def __aenter__(self) -> "AsyncPolyforgeWebSocketClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def connect(self) -> "AsyncPolyforgeWebSocketClient":
+        await asyncio.to_thread(self._client.connect)
+        return self
+
+    async def reconnect(self) -> "AsyncPolyforgeWebSocketClient":
+        await asyncio.to_thread(self._client.reconnect)
+        return self
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._client.close)
+
+    async def send(self, message: WsMessage) -> None:
+        await asyncio.to_thread(self._client.send, message)
+
+    async def receive(self) -> WsMessage:
+        return await asyncio.to_thread(self._client.receive)
+
+    async def receive_event(self) -> WsEvent:
+        return await asyncio.to_thread(self._client.receive_event)
+
+    async def iter_messages(self) -> AsyncIterator[WsMessage]:
+        while True:
+            try:
+                yield await self.receive()
+            except StopIteration:
+                return
+
+    async def iter_events(self) -> AsyncIterator[WsEvent]:
+        async for message in self.iter_messages():
+            yield _parse_event(message)
+
+    async def subscribe_prices(self, token_ids: list[str]) -> None:
+        await asyncio.to_thread(self._client.subscribe_prices, token_ids)
+
+    async def unsubscribe_prices(self, token_ids: list[str]) -> None:
+        await asyncio.to_thread(self._client.unsubscribe_prices, token_ids)
+
+    async def subscribe_whales(self) -> None:
+        await asyncio.to_thread(self._client.subscribe_whales)
+
+    async def unsubscribe_whales(self) -> None:
+        await asyncio.to_thread(self._client.unsubscribe_whales)
+
+    async def subscribe_strategy(self, strategy_id: str) -> None:
+        await asyncio.to_thread(self._client.subscribe_strategy, strategy_id)
+
+    async def unsubscribe_strategy(self, strategy_id: str) -> None:
+        await asyncio.to_thread(self._client.unsubscribe_strategy, strategy_id)
+
+    async def ping(self) -> None:
+        await asyncio.to_thread(self._client.ping)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,249 @@
+import json
+
+import pytest
+
+from polyforge.websocket import (
+    PolyforgeWebSocketClient,
+    WsEvent,
+    WsPriceUpdate,
+    WsWhaleTrade,
+    _build_ws_url,
+)
+
+
+class FakeSocket:
+    def __init__(self, messages=None):
+        self.sent = []
+        self.closed = False
+        self.messages = list(messages or [])
+
+    def send(self, payload):
+        self.sent.append(payload)
+
+    def recv(self):
+        if not self.messages:
+            raise StopIteration
+        return self.messages.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+def test_build_ws_url_uses_ws_scheme_and_token_query():
+    assert _build_ws_url("https://api.polyforge.app/api/v1") == "wss://api.polyforge.app/ws"
+    assert (
+        _build_ws_url("https://api.polyforge.app/api/v1", "jwt-token")
+        == "wss://api.polyforge.app/ws?token=jwt-token"
+    )
+    assert (
+        _build_ws_url("http://localhost:3002", "jwt token")
+        == "ws://localhost:3002/ws?token=jwt+token"
+    )
+
+
+def test_sync_client_connects_with_websocket_client_dependency(monkeypatch):
+    created = {}
+    socket = FakeSocket()
+
+    def fake_create_connection(url, timeout=None, header=None, cookie=None, origin=None):
+        created["url"] = url
+        created["timeout"] = timeout
+        created["header"] = header
+        created["cookie"] = cookie
+        created["origin"] = origin
+        return socket
+
+    monkeypatch.setattr("polyforge.websocket._create_connection", fake_create_connection)
+
+    client = PolyforgeWebSocketClient(
+        token="jwt-token",
+        api_url="https://api.polyforge.app/api/v1",
+        timeout=7.5,
+        origin="https://app.polyforge.app",
+    )
+
+    assert client.connect() is client
+    assert created["url"] == "wss://api.polyforge.app/ws"
+    assert created["timeout"] == 7.5
+    assert created["cookie"] == "pf_token=jwt-token"
+    assert created["origin"] == "https://app.polyforge.app"
+
+
+def test_sync_client_can_use_query_token_auth_for_compatibility(monkeypatch):
+    created = {}
+    socket = FakeSocket()
+
+    def fake_create_connection(url, timeout=None, header=None, cookie=None, origin=None):
+        created["url"] = url
+        created["cookie"] = cookie
+        return socket
+
+    monkeypatch.setattr("polyforge.websocket._create_connection", fake_create_connection)
+
+    client = PolyforgeWebSocketClient(token="jwt-token", auth_mode="query").connect()
+
+    assert client.url == "wss://api.polyforge.app/ws?token=jwt-token"
+    assert created["url"] == "wss://api.polyforge.app/ws?token=jwt-token"
+    assert created["cookie"] is None
+
+
+def test_sync_client_sends_gateway_subscription_messages(monkeypatch):
+    socket = FakeSocket()
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: socket)
+
+    client = PolyforgeWebSocketClient(token="jwt-token").connect()
+    client.subscribe_prices(["token-a", "token-b"])
+    client.unsubscribe_prices(["token-a"])
+    client.subscribe_whales()
+    client.unsubscribe_whales()
+    client.ping()
+
+    assert [json.loads(payload) for payload in socket.sent] == [
+        {"type": "SUBSCRIBE_PRICES", "tokenIds": ["token-a", "token-b"]},
+        {"type": "UNSUBSCRIBE_PRICES", "tokenIds": ["token-a"]},
+        {"type": "SUBSCRIBE_WHALES"},
+        {"type": "UNSUBSCRIBE_WHALES"},
+        {"type": "PING"},
+    ]
+
+
+def test_sync_client_tracks_subscriptions_across_reconnect(monkeypatch):
+    first_socket = FakeSocket()
+    second_socket = FakeSocket()
+    sockets = [first_socket, second_socket]
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: sockets.pop(0))
+
+    client = PolyforgeWebSocketClient(token="jwt-token").connect()
+    client.subscribe_prices(["token-a"])
+    client.subscribe_whales()
+    client.reconnect()
+
+    assert first_socket.closed is True
+    assert [json.loads(payload) for payload in second_socket.sent] == [
+        {"type": "SUBSCRIBE_PRICES", "tokenIds": ["token-a"]},
+        {"type": "SUBSCRIBE_WHALES"},
+    ]
+
+
+def test_sync_client_iter_messages_returns_decoded_gateway_events(monkeypatch):
+    socket = FakeSocket(
+        [
+            "not-json",
+            json.dumps({"type": "AUTH_OK", "timestamp": 1}),
+            json.dumps({"type": "PRICE_UPDATE", "data": {"tokenId": "t1", "price": 0.42}}),
+            json.dumps({"type": "WHALE_TRADE", "data": {"walletAddress": "0xabc"}}),
+        ]
+    )
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: socket)
+
+    client = PolyforgeWebSocketClient(token="jwt-token").connect()
+
+    assert [msg["type"] for msg in client.iter_messages()] == [
+        "AUTH_OK",
+        "PRICE_UPDATE",
+        "WHALE_TRADE",
+    ]
+
+
+def test_sync_client_receive_event_models_known_gateway_events(monkeypatch):
+    socket = FakeSocket(
+        [
+            json.dumps({"type": "PRICE_UPDATE", "data": {"tokenId": "t1", "price": "0.42"}, "timestamp": 11}),
+            json.dumps({"type": "WHALE_TRADE", "data": {"walletAddress": "0xabc"}, "timestamp": 12}),
+            json.dumps({"type": "NOTIFICATION", "data": {"title": "Broadcast"}, "timestamp": 13}),
+        ]
+    )
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: socket)
+
+    client = PolyforgeWebSocketClient(token="jwt-token").connect()
+
+    price = client.receive_event()
+    whale = client.receive_event()
+    notification = client.receive_event()
+
+    assert price == WsPriceUpdate(
+        data={"tokenId": "t1", "price": "0.42"},
+        timestamp=11,
+        raw=price.raw,
+        token_id="t1",
+        price="0.42",
+    )
+    assert price.raw["type"] == "PRICE_UPDATE"
+    assert whale == WsWhaleTrade(data={"walletAddress": "0xabc"}, timestamp=12, raw=whale.raw)
+    assert notification == WsEvent(type="NOTIFICATION", data={"title": "Broadcast"}, timestamp=13, raw=notification.raw)
+
+
+def test_sync_client_closes_underlying_socket(monkeypatch):
+    socket = FakeSocket()
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: socket)
+
+    client = PolyforgeWebSocketClient(token="jwt-token").connect()
+    client.close()
+
+    assert socket.closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_client_can_subscribe_and_read_without_blocking_event_loop(monkeypatch):
+    from polyforge.websocket import AsyncPolyforgeWebSocketClient
+
+    socket = FakeSocket([json.dumps({"type": "PONG", "timestamp": 1})])
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: socket)
+    to_thread_calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("polyforge.websocket.asyncio.to_thread", fake_to_thread)
+
+    async with AsyncPolyforgeWebSocketClient(token="jwt-token") as client:
+        await client.subscribe_prices(["token-a"])
+        message = await client.receive()
+
+    assert json.loads(socket.sent[0]) == {
+        "type": "SUBSCRIBE_PRICES",
+        "tokenIds": ["token-a"],
+    }
+    assert message == {"type": "PONG", "timestamp": 1}
+    assert socket.closed is True
+    assert to_thread_calls == ["connect", "subscribe_prices", "receive", "close"]
+
+
+@pytest.mark.asyncio
+async def test_async_client_tracks_subscriptions_across_reconnect(monkeypatch):
+    from polyforge.websocket import AsyncPolyforgeWebSocketClient
+
+    first_socket = FakeSocket()
+    second_socket = FakeSocket()
+    sockets = [first_socket, second_socket]
+    monkeypatch.setattr("polyforge.websocket._create_connection", lambda *args, **kwargs: sockets.pop(0))
+    to_thread_calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("polyforge.websocket.asyncio.to_thread", fake_to_thread)
+
+    async with AsyncPolyforgeWebSocketClient(token="jwt-token") as client:
+        await client.subscribe_prices(["token-a"])
+        await client.subscribe_strategy("strategy-a")
+        await client.subscribe_whales()
+        await client.reconnect()
+
+    assert first_socket.closed is True
+    assert [json.loads(payload) for payload in second_socket.sent] == [
+        {"type": "SUBSCRIBE_PRICES", "tokenIds": ["token-a"]},
+        {"type": "SUBSCRIBE_STRATEGY", "strategyId": "strategy-a"},
+        {"type": "SUBSCRIBE_WHALES"},
+    ]
+    assert second_socket.closed is True
+    assert to_thread_calls == [
+        "connect",
+        "subscribe_prices",
+        "subscribe_strategy",
+        "subscribe_whales",
+        "reconnect",
+        "close",
+    ]


### PR DESCRIPTION
## Summary

Implement WebSocket realtime client for the Polyforge Python SDK, addressing missing WebSocket gateway support (compat SDK issue #302).

- **PolyforgeWebSocketClient** — Synchronous client with cookie/query auth modes for the /ws gateway
- **AsyncPolyforgeWebSocketClient** — Async wrapper using asyncio.to_thread for non-blocking operation
- **WsEvent, WsPriceUpdate, WsWhaleTrade** — Typed event models for structured access to gateway events
- **Gateway subscriptions** — subscribe_prices, subscribe_whales, subscribe_strategy with reconnect state tracking
- **Dependency** — Added websocket-client>=1.8 to pyproject.toml
- **Documentation** — README updated with WebSocket gateway usage examples

## Verification

- **10 new tests pass** (sync + async clients, URL building, auth modes, subscriptions, reconnect, event parsing)
- **Total test count: 1011** (above 596 minimum)
- **Pyright: 0 errors** on __init__.py and websocket.py (1 cosmetic create_connection false positive)

## Affected Files

- src/polyforge/websocket.py (new) — 330 lines
- src/polyforge/__init__.py (modified) — exports added
- tests/test_websocket.py (new) — 249 lines
- pyproject.toml (modified) — dependency added
- README.md (modified) — WebSocket docs added

## Related

- GitHub: polyforge-sdk-python#302
- Paperclip: POLA-9797