### PR TITLE
feat(sdk-python): add strategy capability discovery support (#298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ asyncio.run(main())
 | `stop_strategy(strategy_id)` | Stop a running strategy |
 | `get_strategy_templates()` | List pre-built strategy templates |
 | `export_strategy(strategy_id)` | Export strategy configuration as a dict |
+| `get_strategy_capabilities()` | Discover server-supported strategy builder capabilities |
+| `get_strategy_design_patterns()` | Discover strategy design pattern guidance |
+| `get_strategy_examples()` | Fetch example strategy definitions for tooling |
 | `watch_strategy(strategy_id)` | Stream live execution events via SSE |
 
 ### Live Execution Watching

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1246,6 +1246,22 @@ class PolyforgeClient:
     def export_strategy(self, strategy_id: str) -> dict:
         return self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/export")
 
+    def get_strategy_capabilities(self) -> dict[str, Any]:
+        """Fetch the strategy builder capability manifest.
+
+        The manifest describes the strategy blocks, execution modes, and other
+        server-supported features available to strategy generation tooling.
+        """
+        return self._get("/api/v1/strategies/capabilities")
+
+    def get_strategy_design_patterns(self) -> dict[str, Any]:
+        """Fetch server-published strategy design patterns."""
+        return self._get("/api/v1/strategies/design-patterns")
+
+    def get_strategy_examples(self) -> dict[str, Any]:
+        """Fetch example strategy definitions for agents and external tooling."""
+        return self._get("/api/v1/strategies/examples")
+
     def update_strategy(
         self,
         strategy_id: str,
@@ -4993,6 +5009,18 @@ class AsyncPolyforgeClient:
 
     async def export_strategy(self, strategy_id: str) -> dict:
         return await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/export")
+
+    async def get_strategy_capabilities(self) -> dict[str, Any]:
+        """Fetch the strategy builder capability manifest."""
+        return await self._get("/api/v1/strategies/capabilities")
+
+    async def get_strategy_design_patterns(self) -> dict[str, Any]:
+        """Fetch server-published strategy design patterns."""
+        return await self._get("/api/v1/strategies/design-patterns")
+
+    async def get_strategy_examples(self) -> dict[str, Any]:
+        """Fetch example strategy definitions for agents and external tooling."""
+        return await self._get("/api/v1/strategies/examples")
 
     async def update_strategy(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3517,6 +3517,90 @@ class TestDiscoveryAndRanking:
         assert "/api/v1/leaderboard" in source
 
 
+class TestStrategyCapabilityDiscovery:
+    """Tests for strategy capability discovery endpoints (#298)."""
+
+    def test_sync_strategy_capability_methods_exist(self):
+        for method in (
+            "get_strategy_capabilities",
+            "get_strategy_design_patterns",
+            "get_strategy_examples",
+        ):
+            assert callable(getattr(PolyforgeClient, method, None))
+
+    def test_async_strategy_capability_methods_exist(self):
+        for method in (
+            "get_strategy_capabilities",
+            "get_strategy_design_patterns",
+            "get_strategy_examples",
+        ):
+            assert callable(getattr(AsyncPolyforgeClient, method, None))
+
+    def test_sync_strategy_capability_paths(self):
+        import inspect
+
+        assert "/api/v1/strategies/capabilities" in inspect.getsource(
+            PolyforgeClient.get_strategy_capabilities
+        )
+        assert "/api/v1/strategies/design-patterns" in inspect.getsource(
+            PolyforgeClient.get_strategy_design_patterns
+        )
+        assert "/api/v1/strategies/examples" in inspect.getsource(
+            PolyforgeClient.get_strategy_examples
+        )
+
+    def test_async_strategy_capability_paths(self):
+        import inspect
+
+        assert "/api/v1/strategies/capabilities" in inspect.getsource(
+            AsyncPolyforgeClient.get_strategy_capabilities
+        )
+        assert "/api/v1/strategies/design-patterns" in inspect.getsource(
+            AsyncPolyforgeClient.get_strategy_design_patterns
+        )
+        assert "/api/v1/strategies/examples" in inspect.getsource(
+            AsyncPolyforgeClient.get_strategy_examples
+        )
+
+    def test_sync_strategy_capability_methods_return_raw_manifest(self):
+        seen_paths = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_paths.append(request.url.path)
+            return httpx.Response(
+                200,
+                json={"version": "1.0", "path": request.url.path},
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        try:
+            assert (
+                client.get_strategy_capabilities()["path"]
+                == "/api/v1/strategies/capabilities"
+            )
+            assert (
+                client.get_strategy_design_patterns()["path"]
+                == "/api/v1/strategies/design-patterns"
+            )
+            assert (
+                client.get_strategy_examples()["path"]
+                == "/api/v1/strategies/examples"
+            )
+        finally:
+            client.close()
+        assert seen_paths == [
+            "/api/v1/strategies/capabilities",
+            "/api/v1/strategies/design-patterns",
+            "/api/v1/strategies/examples",
+        ]
+
+
 class TestPaperTrading:
     """Tests for get_paper_summary and reset_paper_account."""
 


### PR DESCRIPTION
Add Python SDK support for strategy capability discovery endpoints as requested in #298.

- `get_strategy_capabilities()` — Fetch the strategy builder capability manifest
- `get_strategy_design_patterns()` — Fetch server-published design patterns
- `get_strategy_examples()` — Fetch example strategy definitions

Both sync and async clients updated. 1006 tests passed.

API endpoints:
- `GET /api/v1/strategies/capabilities`
- `GET /api/v1/strategies/design-patterns`
- `GET /api/v1/strategies/examples`