### PR TITLE
fix(sdk-python): resolve 4 breaking compatibility mismatches with platform API

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -110,6 +110,7 @@ from polyforge.models import (
     Strategy,
     StrategyBlock,
     StrategyEvent,
+    StrategyHealth,
     StrategyStatusResponse,
     StrategyTemplate,
     SystemHealthPublic,
@@ -1135,6 +1136,10 @@ class PolyforgeClient:
     def get_strategy(self, strategy_id: str) -> Strategy:
         return _parse(Strategy, self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}"))
 
+    def get_strategy_health(self, strategy_id: str) -> StrategyHealth:
+        """Return live health metrics for a strategy. Requires READ scope."""
+        return _parse(StrategyHealth, self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/health"))
+
     def create_strategy(
         self,
         name: str,
@@ -1150,7 +1155,7 @@ class PolyforgeClient:
         safety: list[dict[str, Any]] | None = None,
         logic_blocks: list[dict[str, Any]] | None = None,
         calc_blocks: list[dict[str, Any]] | None = None,
-        kalshi_subaccount: str | None = None,
+        kalshi_subaccount: int | None = None,
         tags: list[str] | None = None,
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
@@ -1199,6 +1204,10 @@ class PolyforgeClient:
         if calc_blocks is not None:
             body["calcBlocks"] = calc_blocks
         if kalshi_subaccount is not None:
+            if not isinstance(kalshi_subaccount, int) or not (0 <= kalshi_subaccount <= 32767):
+                raise ValueError(
+                    f"kalshi_subaccount must be an integer in [0, 32767], got {kalshi_subaccount!r}"
+                )
             body["kalshiSubaccount"] = kalshi_subaccount
         if tags is not None:
             body["tags"] = tags
@@ -1266,7 +1275,7 @@ class PolyforgeClient:
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
         market_slots: list[dict[str, Any]] | None = None,
-        kalshi_subaccount: str | None = None,
+        kalshi_subaccount: int | None = None,
     ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
@@ -1302,6 +1311,10 @@ class PolyforgeClient:
         if market_slots is not None:
             body["marketSlots"] = market_slots
         if kalshi_subaccount is not None:
+            if not isinstance(kalshi_subaccount, int) or not (0 <= kalshi_subaccount <= 32767):
+                raise ValueError(
+                    f"kalshi_subaccount must be an integer in [0, 32767], got {kalshi_subaccount!r}"
+                )
             body["kalshiSubaccount"] = kalshi_subaccount
         return _parse(Strategy, self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
@@ -2917,15 +2930,27 @@ class PolyforgeClient:
         items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketEarningsEntry, e) for e in items]
 
-    def get_polymarket_activity(self, *, activity_type: str | None = None) -> list[PolymarketActivity]:
+    def get_polymarket_activity(
+        self,
+        *,
+        activity_type: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list[PolymarketActivity]:
         """Fetch on-chain activity for the connected Polymarket wallet.
 
         Args:
             activity_type: Optional activity type filter (e.g. ``"TRADE"``, ``"REDEEM"``).
+            offset: Optional zero-based offset for pagination. Must be >= 0.
+            limit: Optional page size. Must be an integer in ``[1, 100]``.
         """
+        if offset is not None and (not isinstance(offset, int) or isinstance(offset, bool) or offset < 0):
+            raise ValueError(f"offset must be an integer >= 0, got {offset!r}")
+        if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not (1 <= limit <= 100)):
+            raise ValueError(f"limit must be an integer in [1, 100], got {limit!r}")
         data = self._get(
             "/api/v1/portfolio/polymarket/activity",
-            params=_strip_none({"type": activity_type}),
+            params=_strip_none({"type": activity_type, "offset": offset, "limit": limit}),
         )
         items = data if isinstance(data, list) else data.get("activities", data.get("data", []))
         return [_parse(PolymarketActivity, a) for a in items]
@@ -4819,6 +4844,10 @@ class AsyncPolyforgeClient:
     async def get_strategy(self, strategy_id: str) -> Strategy:
         return _parse(Strategy, await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}"))
 
+    async def get_strategy_health(self, strategy_id: str) -> StrategyHealth:
+        """Return live health metrics for a strategy. Requires READ scope."""
+        return _parse(StrategyHealth, await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/health"))
+
     async def create_strategy(
         self,
         name: str,
@@ -4834,7 +4863,7 @@ class AsyncPolyforgeClient:
         safety: list[dict[str, Any]] | None = None,
         logic_blocks: list[dict[str, Any]] | None = None,
         calc_blocks: list[dict[str, Any]] | None = None,
-        kalshi_subaccount: str | None = None,
+        kalshi_subaccount: int | None = None,
         tags: list[str] | None = None,
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
@@ -4864,6 +4893,10 @@ class AsyncPolyforgeClient:
         if calc_blocks is not None:
             body["calcBlocks"] = calc_blocks
         if kalshi_subaccount is not None:
+            if not isinstance(kalshi_subaccount, int) or not (0 <= kalshi_subaccount <= 32767):
+                raise ValueError(
+                    f"kalshi_subaccount must be an integer in [0, 32767], got {kalshi_subaccount!r}"
+                )
             body["kalshiSubaccount"] = kalshi_subaccount
         if tags is not None:
             body["tags"] = tags
@@ -4927,7 +4960,7 @@ class AsyncPolyforgeClient:
         variables: list[dict[str, Any]] | None = None,
         canvas: dict[str, Any] | None = None,
         market_slots: list[dict[str, Any]] | None = None,
-        kalshi_subaccount: str | None = None,
+        kalshi_subaccount: int | None = None,
     ) -> Strategy:
         body: dict[str, Any] = {}
         if name is not None:
@@ -4963,6 +4996,10 @@ class AsyncPolyforgeClient:
         if market_slots is not None:
             body["marketSlots"] = market_slots
         if kalshi_subaccount is not None:
+            if not isinstance(kalshi_subaccount, int) or not (0 <= kalshi_subaccount <= 32767):
+                raise ValueError(
+                    f"kalshi_subaccount must be an integer in [0, 32767], got {kalshi_subaccount!r}"
+                )
             body["kalshiSubaccount"] = kalshi_subaccount
         return _parse(Strategy, await self._patch(f"/api/v1/strategies/{_encode_path(strategy_id)}", json=body))
 
@@ -6344,15 +6381,27 @@ class AsyncPolyforgeClient:
         items = data if isinstance(data, list) else data.get("entries", data.get("data", []))
         return [_parse(PolymarketEarningsEntry, e) for e in items]
 
-    async def get_polymarket_activity(self, *, activity_type: str | None = None) -> list[PolymarketActivity]:
+    async def get_polymarket_activity(
+        self,
+        *,
+        activity_type: str | None = None,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list[PolymarketActivity]:
         """Fetch on-chain activity for the connected Polymarket wallet.
 
         Args:
             activity_type: Optional activity type filter (e.g. ``"TRADE"``, ``"REDEEM"``).
+            offset: Optional zero-based offset for pagination. Must be >= 0.
+            limit: Optional page size. Must be an integer in ``[1, 100]``.
         """
+        if offset is not None and (not isinstance(offset, int) or isinstance(offset, bool) or offset < 0):
+            raise ValueError(f"offset must be an integer >= 0, got {offset!r}")
+        if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not (1 <= limit <= 100)):
+            raise ValueError(f"limit must be an integer in [1, 100], got {limit!r}")
         data = await self._get(
             "/api/v1/portfolio/polymarket/activity",
-            params=_strip_none({"type": activity_type}),
+            params=_strip_none({"type": activity_type, "offset": offset, "limit": limit}),
         )
         items = data if isinstance(data, list) else data.get("activities", data.get("data", []))
         return [_parse(PolymarketActivity, a) for a in items]

--- a/src/polyforge/models.py
+++ b/src/polyforge/models.py
@@ -290,23 +290,26 @@ StrategyTemplate = Strategy
 
 @dataclass
 class Position:
-    """An open position within a portfolio.
+    """An open position returned by GET /api/v1/portfolio.
 
     Monetary fields are typed as ``str`` because the platform returns
     decimal strings to preserve precision (#34).
+
+    ``side`` carries the YES/NO outcome label, not a BUY/SELL direction —
+    the platform's naming is historical (see core issue tracker).
     """
 
     id: str = ""
     market_id: str = ""
+    market_title: str = ""
+    market_category: str | None = None
     token_id: str = ""
-    outcome: str = ""
     side: str = ""
     size: str = ""
-    avg_price: str = ""
+    avg_entry_price: str = ""
     current_price: str = ""
     unrealized_pnl: str = ""
-    realized_pnl: str = ""
-    opened_at: str = ""
+    resolution_status: str = ""
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1865,13 +1865,12 @@ class TestOrderMonetaryFields:
         """Position monetary fields must be str."""
         pos = Position(
             size="100.00",
-            avg_price="0.55",
+            avg_entry_price="0.55",
             current_price="0.65",
             unrealized_pnl="10.00",
-            realized_pnl="5.00",
         )
         assert isinstance(pos.size, str)
-        assert isinstance(pos.avg_price, str)
+        assert isinstance(pos.avg_entry_price, str)
         assert pos.unrealized_pnl == "10.00"
 
 
@@ -1884,18 +1883,18 @@ class TestPositionOrderFieldAlignment:
         assert pos.token_id == "0xabc123"
 
     def test_position_has_outcome(self):
-        """Position must have outcome field for YES/NO (#143)."""
-        pos_yes = Position(outcome="YES")
-        pos_no = Position(outcome="NO")
-        assert pos_yes.outcome == "YES"
-        assert pos_no.outcome == "NO"
+        """Position must have side field for YES/NO outcome label (#143)."""
+        pos_yes = Position(side="YES")
+        pos_no = Position(side="NO")
+        assert pos_yes.side == "YES"
+        assert pos_no.side == "NO"
 
-    def test_position_uses_avg_price_not_entry_price(self):
-        """Position must use avg_price (platform field), not entry_price (#143)."""
+    def test_position_uses_avg_entry_price_not_avg_price(self):
+        """Position must use avg_entry_price (platform field), not avg_price (#143)."""
         import dataclasses
         field_names = {f.name for f in dataclasses.fields(Position)}
-        assert "avg_price" in field_names
-        assert "entry_price" not in field_names
+        assert "avg_entry_price" in field_names
+        assert "avg_price" not in field_names
 
     def test_position_no_market_name_phantom_field(self):
         """Position must not have phantom market_name field (#143)."""
@@ -1908,20 +1907,20 @@ class TestPositionOrderFieldAlignment:
         api_response = {
             "id": "pos-1",
             "marketId": "mkt-abc",
+            "marketTitle": "Will BTC hit $100K?",
+            "marketCategory": "Crypto",
             "tokenId": "0xtoken",
-            "outcome": "YES",
-            "side": "BUY",
+            "side": "YES",
             "size": "50.00",
-            "avgPrice": "0.60",
+            "avgEntryPrice": "0.60",
             "currentPrice": "0.70",
             "unrealizedPnl": "5.00",
-            "realizedPnl": "0.00",
-            "openedAt": "2026-01-01T00:00:00Z",
+            "resolutionStatus": "UNRESOLVED",
         }
         pos = _parse(Position, api_response)
         assert pos.token_id == "0xtoken"
-        assert pos.outcome == "YES"
-        assert pos.avg_price == "0.60"
+        assert pos.side == "YES"
+        assert pos.avg_entry_price == "0.60"
 
     def test_order_has_token_id(self):
         """Order must have token_id field (#143)."""
@@ -6058,12 +6057,12 @@ class TestPositionPlatformContract:
         assert pos.token_id == "tok-1"
 
     def test_position_has_outcome_field(self):
-        pos = Position(outcome="YES")
-        assert pos.outcome == "YES"
+        pos = Position(side="YES")
+        assert pos.side == "YES"
 
-    def test_position_uses_avg_price_not_entry_price(self):
-        pos = Position(avg_price="0.55")
-        assert pos.avg_price == "0.55"
+    def test_position_uses_avg_entry_price_not_avg_price(self):
+        pos = Position(avg_entry_price="0.55")
+        assert pos.avg_entry_price == "0.55"
 
     def test_position_no_entry_price_field(self):
         assert not hasattr(Position, "entry_price") or "entry_price" not in {
@@ -6081,32 +6080,32 @@ class TestPositionPlatformContract:
 
     def test_position_outcome_defaults_to_empty(self):
         pos = Position()
-        assert pos.outcome == ""
+        assert pos.side == ""
 
-    def test_position_avg_price_defaults_to_empty(self):
+    def test_position_avg_entry_price_defaults_to_empty(self):
         pos = Position()
-        assert pos.avg_price == ""
+        assert pos.avg_entry_price == ""
 
     def test_position_parses_from_platform_response(self):
         api_response = {
             "id": "pos-1",
             "marketId": "mkt-1",
+            "marketTitle": "Will BTC hit $100K?",
+            "marketCategory": "Crypto",
             "tokenId": "tok-1",
-            "outcome": "YES",
-            "side": "BUY",
+            "side": "YES",
             "size": "100.00",
-            "avgPrice": "0.55",
+            "avgEntryPrice": "0.55",
             "currentPrice": "0.65",
             "unrealizedPnl": "10.00",
-            "realizedPnl": "0.00",
-            "openedAt": "2026-01-01T00:00:00Z",
+            "resolutionStatus": "UNRESOLVED",
         }
         pos = _parse(Position, api_response)
         assert pos.id == "pos-1"
         assert pos.market_id == "mkt-1"
         assert pos.token_id == "tok-1"
-        assert pos.outcome == "YES"
-        assert pos.avg_price == "0.55"
+        assert pos.side == "YES"
+        assert pos.avg_entry_price == "0.55"
         assert pos.current_price == "0.65"
 
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -168,6 +168,7 @@ def test_sync_client_receive_event_models_known_gateway_events(monkeypatch):
         token_id="t1",
         price="0.42",
     )
+    assert price.raw is not None
     assert price.raw["type"] == "PRICE_UPDATE"
     assert whale == WsWhaleTrade(data={"walletAddress": "0xabc"}, timestamp=12, raw=whale.raw)
     assert notification == WsEvent(type="NOTIFICATION", data={"title": "Broadcast"}, timestamp=13, raw=notification.raw)


### PR DESCRIPTION
## Summary

Resolves 4 breaking compatibility issues in the Python SDK.

### Changes

- **#290 Position**: Match GET /api/v1/portfolio shape - add market_title, market_category, avg_entry_price, resolution_status; side carries YES/NO outcome label; drop avg_price, realized_pnl, opened_at, outcome
- **#292 getStrategyHealth**: Add get_strategy_health() to both sync PolyforgeClient and async AsyncPolyforgeClient
- **#301 kalshi_subaccount**: Change type from str|None to int|None with [0,32767] validation in create_strategy and update_strategy (sync + async)
- **#303 getPolymarketActivity**: Add offset/limit pagination params with validation

### Already pre-fixed
- #299 (voteMarketSentiment direction YES/NO) and #300 (Webhook.active field) were fixed in earlier commits.

### Verification
- 1115/1117 tests pass (2 pre-existing test_conditional_order failures unrelated)

Closes #290, Closes #292, Closes #301, Closes #303