### PR TITLE
fix(sdk-python): normalize copy target wallet

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -3105,7 +3105,7 @@ class PolyforgeClient:
         Returns:
             The created :class:`CopyConfig`.
         """
-        body: dict[str, Any] = {"targetWallet": target_wallet}
+        body: dict[str, Any] = {"targetWallet": target_wallet.lower()}
         if mode is not None:
             body["mode"] = mode
         if size_value is not None:
@@ -6617,7 +6617,7 @@ class AsyncPolyforgeClient:
         price_offset: float | None = None,
     ) -> CopyConfig:
         """Create a new copy-trading configuration."""
-        body: dict[str, Any] = {"targetWallet": target_wallet}
+        body: dict[str, Any] = {"targetWallet": target_wallet.lower()}
         if mode is not None:
             body["mode"] = mode
         if size_value is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8424,6 +8424,31 @@ class TestTradingCopyNumericValidation:
 
         client.close()
 
+    def test_create_copy_config_normalizes_target_wallet_to_lowercase(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._post = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            "mode": "PERCENTAGE",
+            "sizeValue": "10",
+            "maxExposure": "500",
+            "maxDailyLoss": "100",
+            "priceOffset": "0",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+        client.create_copy_config("0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD")
+        assert client._post.call_args.kwargs["json"]["targetWallet"] == (
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        )
+        client.close()
+
     def test_create_copy_config_sends_numeric_fields_as_strings(self):
         from unittest.mock import MagicMock
 
@@ -8771,6 +8796,36 @@ class TestTradingCopyNumericValidation:
                 )
             with pytest.raises(ValueError, match="Infinity"):
                 await client.update_copy_config("copy-1", price_offset="Infinity")  # type: ignore[arg-type]
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_create_copy_config_normalizes_target_wallet_to_lowercase(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            client._post = AsyncMock(return_value={
+                "id": "copy-1",
+                "userId": "user-1",
+                "targetWallet": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "mode": "PERCENTAGE",
+                "sizeValue": "10",
+                "maxExposure": "500",
+                "maxDailyLoss": "100",
+                "priceOffset": "0",
+                "status": "ACTIVE",
+                "totalCopied": 0,
+                "totalPnl": "0",
+                "createdAt": "2026-04-29T00:00:00Z",
+                "updatedAt": "2026-04-29T00:00:00Z",
+            })
+
+            await client.create_copy_config("0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD")
+            assert client._post.call_args.kwargs["json"]["targetWallet"] == (
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            )
             await client.close()
 
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Lowercase target_wallet before serializing create_copy_config requests in sync and async clients
- Add sync and async regression coverage for mixed-case target wallets

## Test Plan
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src .venv/bin/pytest tests/test_client.py::TestTradingCopyNumericValidation::test_create_copy_config_normalizes_target_wallet_to_lowercase tests/test_client.py::TestTradingCopyNumericValidation::test_async_create_copy_config_normalizes_target_wallet_to_lowercase tests/test_client.py::TestTradingCopyNumericValidation::test_create_copy_config_sends_numeric_fields_as_strings tests/test_client.py::TestTradingCopyNumericValidation::test_async_copy_and_whale_paths_validate_before_awaiting -q -p no:cacheprovider
- git diff --check

Closes #286