### PR TITLE
feat: add strategy health and validation endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 async clients now expose the upcoming strategy AI/operator API surface:
 
 - `get_strategy_health(strategy_id)` → `StrategyHealth`
-- `validate_strategy_blocks(strategy_id, blocks)` → `StrategyBlockValidationResult`
+- `validate_strategy_blocks(blocks)` → `StrategyBlockValidationResult`
 - `list_strategy_block_types()` → `list[StrategyBlockType]`
 - `get_block_schema(block_type)` → `StrategyBlockSchema`
 - `preview_strategy_update(strategy_id, params)` → `StrategyUpdatePreview`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+**Strategy health and validation endpoints (POLA-14530 / #297)** — sync and
+async clients now expose the upcoming strategy AI/operator API surface:
+
+- `get_strategy_health(strategy_id)` → `StrategyHealth`
+- `validate_strategy_blocks(strategy_id, blocks)` → `StrategyBlockValidationResult`
+- `list_strategy_block_types()` → `list[StrategyBlockType]`
+- `get_block_schema(block_type)` → `StrategyBlockSchema`
+- `preview_strategy_update(strategy_id, params)` → `StrategyUpdatePreview`
+- `explain_strategy_decision(strategy_id, params)` → `StrategyDecisionExplanation`
+
+Path parameters are URL-encoded and validation/preview/explanation responses
+parse into typed dataclasses, including nested validation issues.
+
 **Misc public utility endpoints (POLA-1857)** — eighteen endpoint methods
 filling gaps surfaced by the weekly SDK + MCP compatibility audit. All are
 available on both `PolyforgeClient` and `AsyncPolyforgeClient`:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ asyncio.run(main())
 | `start_strategy(strategy_id, mode)` | Start a strategy (`"paper"` or `"live"`) |
 | `stop_strategy(strategy_id)` | Stop a running strategy |
 | `get_strategy_health(strategy_id)` | Get live execution health metrics |
-| `validate_strategy_blocks(strategy_id, blocks)` | Validate strategy block groups before saving |
+| `validate_strategy_blocks(blocks)` | Validate strategy block groups before saving |
 | `list_strategy_block_types()` | List available strategy builder block types |
 | `get_block_schema(block_type)` | Fetch the schema for a specific block type |
 | `preview_strategy_update(strategy_id, params)` | Preview a strategy update without applying it |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ asyncio.run(main())
 | `create_strategy_from_description(description, market_id)` | AI-generate a strategy from a text description |
 | `start_strategy(strategy_id, mode)` | Start a strategy (`"paper"` or `"live"`) |
 | `stop_strategy(strategy_id)` | Stop a running strategy |
+| `get_strategy_health(strategy_id)` | Get live execution health metrics |
+| `validate_strategy_blocks(strategy_id, blocks)` | Validate strategy block groups before saving |
+| `list_strategy_block_types()` | List available strategy builder block types |
+| `get_block_schema(block_type)` | Fetch the schema for a specific block type |
+| `preview_strategy_update(strategy_id, params)` | Preview a strategy update without applying it |
+| `explain_strategy_decision(strategy_id, params)` | Explain an AI/operator strategy decision |
 | `get_strategy_templates()` | List pre-built strategy templates |
 | `export_strategy(strategy_id)` | Export strategy configuration as a dict |
 | `get_strategy_capabilities()` | Discover server-supported strategy builder capabilities |

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -1191,14 +1191,13 @@ class PolyforgeClient:
 
     def validate_strategy_blocks(
         self,
-        strategy_id: str,
         blocks: dict[str, Any],
     ) -> StrategyBlockValidationResult:
         """Validate strategy block configuration before saving or deploying."""
         return _parse(
             StrategyBlockValidationResult,
             self._post(
-                f"/api/v1/strategies/{_encode_path(strategy_id)}/validate-blocks",
+                "/api/v1/strategies/validate-blocks",
                 json=blocks,
             ),
         )
@@ -1207,14 +1206,14 @@ class PolyforgeClient:
         """List available strategy builder block types."""
         return [
             _parse(StrategyBlockType, item)
-            for item in self._get("/api/v1/strategy-blocks")
+            for item in self._get("/api/v1/strategies/block-types")
         ]
 
     def get_block_schema(self, block_type: str) -> StrategyBlockSchema:
         """Fetch the JSON schema for a specific strategy block type."""
         return _parse(
             StrategyBlockSchema,
-            self._get(f"/api/v1/strategy-blocks/{_encode_path(block_type)}"),
+            self._get(f"/api/v1/strategies/block-schema/{_encode_path(block_type)}"),
         )
 
     def preview_strategy_update(
@@ -1240,7 +1239,7 @@ class PolyforgeClient:
         return _parse(
             StrategyDecisionExplanation,
             self._post(
-                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain",
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain-decision",
                 json=params,
             ),
         )
@@ -4950,14 +4949,13 @@ class AsyncPolyforgeClient:
 
     async def validate_strategy_blocks(
         self,
-        strategy_id: str,
         blocks: dict[str, Any],
     ) -> StrategyBlockValidationResult:
         """Validate strategy block configuration before saving or deploying."""
         return _parse(
             StrategyBlockValidationResult,
             await self._post(
-                f"/api/v1/strategies/{_encode_path(strategy_id)}/validate-blocks",
+                "/api/v1/strategies/validate-blocks",
                 json=blocks,
             ),
         )
@@ -4966,14 +4964,14 @@ class AsyncPolyforgeClient:
         """List available strategy builder block types."""
         return [
             _parse(StrategyBlockType, item)
-            for item in await self._get("/api/v1/strategy-blocks")
+            for item in await self._get("/api/v1/strategies/block-types")
         ]
 
     async def get_block_schema(self, block_type: str) -> StrategyBlockSchema:
         """Fetch the JSON schema for a specific strategy block type."""
         return _parse(
             StrategyBlockSchema,
-            await self._get(f"/api/v1/strategy-blocks/{_encode_path(block_type)}"),
+            await self._get(f"/api/v1/strategies/block-schema/{_encode_path(block_type)}"),
         )
 
     async def preview_strategy_update(
@@ -4999,7 +4997,7 @@ class AsyncPolyforgeClient:
         return _parse(
             StrategyDecisionExplanation,
             await self._post(
-                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain",
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain-decision",
                 json=params,
             ),
         )

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -110,10 +110,16 @@ from polyforge.models import (
     SpreadSummary,
     Strategy,
     StrategyBlock,
+    StrategyBlockSchema,
+    StrategyBlockType,
+    StrategyBlockValidationIssue,
+    StrategyBlockValidationResult,
+    StrategyDecisionExplanation,
     StrategyEvent,
     StrategyHealth,
     StrategyStatusResponse,
     StrategyTemplate,
+    StrategyUpdatePreview,
     SystemHealthPublic,
     SystemHealthAuthenticated,
     TickSizeInfo,
@@ -157,6 +163,7 @@ T = TypeVar("T")
 _FIELD_ALIASES: dict[str, dict[str, str]] = {
     "PriceHistoryEntry": {"time": "timestamp"},
     "PersonalDataExport": {"_meta": "meta"},
+    "StrategyHealth": {"errorCount24h": "error_count_24h"},
 }
 
 _MODEL_REGISTRY: dict[str, type] = {
@@ -165,8 +172,15 @@ _MODEL_REGISTRY: dict[str, type] = {
     "Token": Token,
     "Strategy": Strategy,
     "StrategyBlock": StrategyBlock,
+    "StrategyBlockSchema": StrategyBlockSchema,
+    "StrategyBlockType": StrategyBlockType,
+    "StrategyBlockValidationIssue": StrategyBlockValidationIssue,
+    "StrategyBlockValidationResult": StrategyBlockValidationResult,
+    "StrategyDecisionExplanation": StrategyDecisionExplanation,
+    "StrategyHealth": StrategyHealth,
     "StrategyStatusResponse": StrategyStatusResponse,
     "StrategyTemplate": StrategyTemplate,
+    "StrategyUpdatePreview": StrategyUpdatePreview,
     "Portfolio": Portfolio,
     "Position": Position,
     "Order": Order,
@@ -1174,6 +1188,62 @@ class PolyforgeClient:
     def get_strategy_health(self, strategy_id: str) -> StrategyHealth:
         """Return live health metrics for a strategy. Requires READ scope."""
         return _parse(StrategyHealth, self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/health"))
+
+    def validate_strategy_blocks(
+        self,
+        strategy_id: str,
+        blocks: dict[str, Any],
+    ) -> StrategyBlockValidationResult:
+        """Validate strategy block configuration before saving or deploying."""
+        return _parse(
+            StrategyBlockValidationResult,
+            self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/validate-blocks",
+                json=blocks,
+            ),
+        )
+
+    def list_strategy_block_types(self) -> list[StrategyBlockType]:
+        """List available strategy builder block types."""
+        return [
+            _parse(StrategyBlockType, item)
+            for item in self._get("/api/v1/strategy-blocks")
+        ]
+
+    def get_block_schema(self, block_type: str) -> StrategyBlockSchema:
+        """Fetch the JSON schema for a specific strategy block type."""
+        return _parse(
+            StrategyBlockSchema,
+            self._get(f"/api/v1/strategy-blocks/{_encode_path(block_type)}"),
+        )
+
+    def preview_strategy_update(
+        self,
+        strategy_id: str,
+        params: dict[str, Any],
+    ) -> StrategyUpdatePreview:
+        """Preview a strategy update without applying it."""
+        return _parse(
+            StrategyUpdatePreview,
+            self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/preview-update",
+                json=params,
+            ),
+        )
+
+    def explain_strategy_decision(
+        self,
+        strategy_id: str,
+        params: dict[str, Any],
+    ) -> StrategyDecisionExplanation:
+        """Explain a strategy decision for transparency and debugging."""
+        return _parse(
+            StrategyDecisionExplanation,
+            self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain",
+                json=params,
+            ),
+        )
 
     def create_strategy(
         self,
@@ -4877,6 +4947,62 @@ class AsyncPolyforgeClient:
     async def get_strategy_health(self, strategy_id: str) -> StrategyHealth:
         """Return live health metrics for a strategy. Requires READ scope."""
         return _parse(StrategyHealth, await self._get(f"/api/v1/strategies/{_encode_path(strategy_id)}/health"))
+
+    async def validate_strategy_blocks(
+        self,
+        strategy_id: str,
+        blocks: dict[str, Any],
+    ) -> StrategyBlockValidationResult:
+        """Validate strategy block configuration before saving or deploying."""
+        return _parse(
+            StrategyBlockValidationResult,
+            await self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/validate-blocks",
+                json=blocks,
+            ),
+        )
+
+    async def list_strategy_block_types(self) -> list[StrategyBlockType]:
+        """List available strategy builder block types."""
+        return [
+            _parse(StrategyBlockType, item)
+            for item in await self._get("/api/v1/strategy-blocks")
+        ]
+
+    async def get_block_schema(self, block_type: str) -> StrategyBlockSchema:
+        """Fetch the JSON schema for a specific strategy block type."""
+        return _parse(
+            StrategyBlockSchema,
+            await self._get(f"/api/v1/strategy-blocks/{_encode_path(block_type)}"),
+        )
+
+    async def preview_strategy_update(
+        self,
+        strategy_id: str,
+        params: dict[str, Any],
+    ) -> StrategyUpdatePreview:
+        """Preview a strategy update without applying it."""
+        return _parse(
+            StrategyUpdatePreview,
+            await self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/preview-update",
+                json=params,
+            ),
+        )
+
+    async def explain_strategy_decision(
+        self,
+        strategy_id: str,
+        params: dict[str, Any],
+    ) -> StrategyDecisionExplanation:
+        """Explain a strategy decision for transparency and debugging."""
+        return _parse(
+            StrategyDecisionExplanation,
+            await self._post(
+                f"/api/v1/strategies/{_encode_path(strategy_id)}/explain",
+                json=params,
+            ),
+        )
 
     async def create_strategy(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3902,7 +3902,7 @@ class TestStrategyHealthAndValidationEndpoints:
     def test_validate_strategy_blocks_posts_body_and_parses_nested_issues(self):
         def handler(request: httpx.Request) -> httpx.Response:
             assert request.method == "POST"
-            assert request.url.path == "/api/v1/strategies/s-1/validate-blocks"
+            assert request.url.path == "/api/v1/strategies/validate-blocks"
             assert json.loads(request.content) == {"triggers": []}
             return httpx.Response(200, json={
                 "valid": False,
@@ -3921,7 +3921,7 @@ class TestStrategyHealthAndValidationEndpoints:
 
         client = self._client_with(handler)
         try:
-            result = client.validate_strategy_blocks("s-1", {"triggers": []})
+            result = client.validate_strategy_blocks({"triggers": []})
         finally:
             client.close()
 
@@ -3936,7 +3936,7 @@ class TestStrategyHealthAndValidationEndpoints:
 
         def handler(request: httpx.Request) -> httpx.Response:
             seen_paths.append(request.url.raw_path.decode())
-            if request.url.path == "/api/v1/strategy-blocks":
+            if request.url.path == "/api/v1/strategies/block-types":
                 return httpx.Response(200, json=[{
                     "type": "price-checks",
                     "label": "Price Checks",
@@ -3962,8 +3962,8 @@ class TestStrategyHealthAndValidationEndpoints:
             client.close()
 
         assert seen_paths == [
-            "/api/v1/strategy-blocks",
-            "/api/v1/strategy-blocks/special%20type%2Fname",
+            "/api/v1/strategies/block-types",
+            "/api/v1/strategies/block-schema/special%20type%2Fname",
         ]
         assert isinstance(block_types[0], StrategyBlockType)
         assert block_types[0].type == "price-checks"
@@ -4000,7 +4000,7 @@ class TestStrategyHealthAndValidationEndpoints:
 
         assert seen == [
             ("POST", "/api/v1/strategies/strategy%2Fid/preview-update", {"tickMs": 5000}),
-            ("POST", "/api/v1/strategies/strategy%2Fid/explain", {"decisionId": "d-1"}),
+            ("POST", "/api/v1/strategies/strategy%2Fid/explain-decision", {"decisionId": "d-1"}),
         ]
         assert isinstance(preview, StrategyUpdatePreview)
         assert preview.estimated_impact == {"risk": "low"}
@@ -4018,9 +4018,9 @@ class TestStrategyHealthAndValidationEndpoints:
                 return httpx.Response(200, json={"avgLatencyMs": 0, "errorCount24h": 0, "slippageBps": 0})
             if request.url.path.endswith("/validate-blocks"):
                 return httpx.Response(200, json={"valid": True, "issues": [], "warnings": [], "normalizedBlocks": {}})
-            if request.url.path == "/api/v1/strategy-blocks":
+            if request.url.path == "/api/v1/strategies/block-types":
                 return httpx.Response(200, json=[])
-            if request.url.path.startswith("/api/v1/strategy-blocks/"):
+            if request.url.path.startswith("/api/v1/strategies/block-schema/"):
                 return httpx.Response(200, json={"type": "price", "schema": {}, "uiSchema": {}, "defaults": {}, "examples": []})
             if request.url.path.endswith("/preview-update"):
                 return httpx.Response(200, json={"strategy": {}, "validation": {}, "diff": {}, "estimatedImpact": {}})
@@ -4030,7 +4030,7 @@ class TestStrategyHealthAndValidationEndpoints:
             client = self._async_client_with(handler)
             try:
                 await client.get_strategy_health("strategy/id")
-                await client.validate_strategy_blocks("strategy/id", {"triggers": []})
+                await client.validate_strategy_blocks({"triggers": []})
                 await client.list_strategy_block_types()
                 await client.get_block_schema("special type/name")
                 await client.preview_strategy_update("strategy/id", {"tickMs": 5000})
@@ -4042,11 +4042,11 @@ class TestStrategyHealthAndValidationEndpoints:
 
         assert seen == [
             ("GET", "/api/v1/strategies/strategy%2Fid/health"),
-            ("POST", "/api/v1/strategies/strategy%2Fid/validate-blocks"),
-            ("GET", "/api/v1/strategy-blocks"),
-            ("GET", "/api/v1/strategy-blocks/special%20type%2Fname"),
+            ("POST", "/api/v1/strategies/validate-blocks"),
+            ("GET", "/api/v1/strategies/block-types"),
+            ("GET", "/api/v1/strategies/block-schema/special%20type%2Fname"),
             ("POST", "/api/v1/strategies/strategy%2Fid/preview-update"),
-            ("POST", "/api/v1/strategies/strategy%2Fid/explain"),
+            ("POST", "/api/v1/strategies/strategy%2Fid/explain-decision"),
         ]
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,9 +59,16 @@ from polyforge.models import (
     MyReferralsResponse,
     RewardMarket,
     Strategy,
+    StrategyBlockSchema,
+    StrategyBlockType,
+    StrategyBlockValidationIssue,
+    StrategyBlockValidationResult,
+    StrategyDecisionExplanation,
     StrategyEvent,
     StrategyEventType,
     StrategyExecMode,
+    StrategyHealth,
+    StrategyUpdatePreview,
     StrategyVisibility,
     TraderScore,
     UserReward,
@@ -3814,6 +3821,232 @@ class TestStrategyCapabilityDiscovery:
             "/api/v1/strategies/capabilities",
             "/api/v1/strategies/design-patterns",
             "/api/v1/strategies/examples",
+        ]
+
+
+class TestStrategyHealthAndValidationEndpoints:
+    """Tests for strategy health and validation/operator endpoints (#297)."""
+
+    @staticmethod
+    def _client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = PolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.Client(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    @staticmethod
+    def _async_client_with(handler):
+        transport = httpx.MockTransport(handler)
+        client = AsyncPolyforgeClient(api_key="test", api_url="http://localhost:9999")
+        client._client = httpx.AsyncClient(
+            base_url="http://localhost:9999",
+            headers={"Authorization": "Bearer test"},
+            transport=transport,
+        )
+        return client
+
+    def test_sync_strategy_health_and_validation_methods_exist(self):
+        for method in (
+            "get_strategy_health",
+            "validate_strategy_blocks",
+            "list_strategy_block_types",
+            "get_block_schema",
+            "preview_strategy_update",
+            "explain_strategy_decision",
+        ):
+            assert callable(getattr(PolyforgeClient, method, None))
+
+    def test_async_strategy_health_and_validation_methods_exist(self):
+        for method in (
+            "get_strategy_health",
+            "validate_strategy_blocks",
+            "list_strategy_block_types",
+            "get_block_schema",
+            "preview_strategy_update",
+            "explain_strategy_decision",
+        ):
+            assert callable(getattr(AsyncPolyforgeClient, method, None))
+
+    def test_get_strategy_health_parses_typed_response(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "GET"
+            assert request.url.raw_path.decode() == "/api/v1/strategies/strategy%2Fid/health"
+            return httpx.Response(200, json={
+                "fillRate": 0.75,
+                "avgLatencyMs": 12.5,
+                "errorCount24h": 1,
+                "slippageBps": 2.4,
+                "winRate": 0.6,
+                "totalPnl": 42.25,
+                "maxDrawdown": 0.1,
+                "totalOrders": 8,
+                "filledOrders": 6,
+                "lastUpdated": "2026-06-30T10:00:00Z",
+            })
+
+        client = self._client_with(handler)
+        try:
+            result = client.get_strategy_health("strategy/id")
+        finally:
+            client.close()
+
+        assert isinstance(result, StrategyHealth)
+        assert result.fill_rate == 0.75
+        assert result.avg_latency_ms == 12.5
+        assert result.error_count_24h == 1
+
+    def test_validate_strategy_blocks_posts_body_and_parses_nested_issues(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/api/v1/strategies/s-1/validate-blocks"
+            assert json.loads(request.content) == {"triggers": []}
+            return httpx.Response(200, json={
+                "valid": False,
+                "issues": [{
+                    "path": "triggers[0]",
+                    "message": "Missing trigger",
+                    "code": "MISSING_TRIGGER",
+                    "severity": "error",
+                    "blockId": "b-1",
+                    "blockType": "PRICE_CHECK",
+                    "suggestion": "Add a trigger block.",
+                }],
+                "warnings": [],
+                "normalizedBlocks": {"triggers": []},
+            })
+
+        client = self._client_with(handler)
+        try:
+            result = client.validate_strategy_blocks("s-1", {"triggers": []})
+        finally:
+            client.close()
+
+        assert isinstance(result, StrategyBlockValidationResult)
+        assert result.valid is False
+        assert isinstance(result.issues[0], StrategyBlockValidationIssue)
+        assert result.issues[0].block_id == "b-1"
+        assert result.normalized_blocks == {"triggers": []}
+
+    def test_list_strategy_block_types_and_schema_are_typed_and_encoded(self):
+        seen_paths = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_paths.append(request.url.raw_path.decode())
+            if request.url.path == "/api/v1/strategy-blocks":
+                return httpx.Response(200, json=[{
+                    "type": "price-checks",
+                    "label": "Price Checks",
+                    "category": "validation",
+                    "description": "Price validation blocks",
+                    "version": "1",
+                    "deprecated": False,
+                    "tags": ["core"],
+                }])
+            return httpx.Response(200, json={
+                "type": "special type/name",
+                "schema": {"type": "object"},
+                "uiSchema": {"order": ["price"]},
+                "defaults": {"price": 0.5},
+                "examples": [{"price": 0.6}],
+            })
+
+        client = self._client_with(handler)
+        try:
+            block_types = client.list_strategy_block_types()
+            schema = client.get_block_schema("special type/name")
+        finally:
+            client.close()
+
+        assert seen_paths == [
+            "/api/v1/strategy-blocks",
+            "/api/v1/strategy-blocks/special%20type%2Fname",
+        ]
+        assert isinstance(block_types[0], StrategyBlockType)
+        assert block_types[0].type == "price-checks"
+        assert isinstance(schema, StrategyBlockSchema)
+        assert schema.ui_schema == {"order": ["price"]}
+
+    def test_preview_update_and_explain_decision_post_payloads(self):
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append((request.method, request.url.raw_path.decode(), json.loads(request.content)))
+            if request.url.path.endswith("/preview-update"):
+                return httpx.Response(200, json={
+                    "strategy": {"id": "s-1"},
+                    "validation": {"valid": True},
+                    "diff": {"tickMs": [1000, 5000]},
+                    "estimatedImpact": {"risk": "low"},
+                })
+            return httpx.Response(200, json={
+                "summary": "Order passed threshold checks.",
+                "rationale": ["price above target"],
+                "confidence": 0.9,
+                "inputs": {"price": 0.6},
+                "decision": {"action": "BUY"},
+                "relatedEvents": [{"id": "evt-1"}],
+            })
+
+        client = self._client_with(handler)
+        try:
+            preview = client.preview_strategy_update("strategy/id", {"tickMs": 5000})
+            explanation = client.explain_strategy_decision("strategy/id", {"decisionId": "d-1"})
+        finally:
+            client.close()
+
+        assert seen == [
+            ("POST", "/api/v1/strategies/strategy%2Fid/preview-update", {"tickMs": 5000}),
+            ("POST", "/api/v1/strategies/strategy%2Fid/explain", {"decisionId": "d-1"}),
+        ]
+        assert isinstance(preview, StrategyUpdatePreview)
+        assert preview.estimated_impact == {"risk": "low"}
+        assert isinstance(explanation, StrategyDecisionExplanation)
+        assert explanation.summary == "Order passed threshold checks."
+
+    def test_async_methods_use_matching_paths(self):
+        import asyncio
+
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append((request.method, request.url.raw_path.decode()))
+            if request.url.path.endswith("/health"):
+                return httpx.Response(200, json={"avgLatencyMs": 0, "errorCount24h": 0, "slippageBps": 0})
+            if request.url.path.endswith("/validate-blocks"):
+                return httpx.Response(200, json={"valid": True, "issues": [], "warnings": [], "normalizedBlocks": {}})
+            if request.url.path == "/api/v1/strategy-blocks":
+                return httpx.Response(200, json=[])
+            if request.url.path.startswith("/api/v1/strategy-blocks/"):
+                return httpx.Response(200, json={"type": "price", "schema": {}, "uiSchema": {}, "defaults": {}, "examples": []})
+            if request.url.path.endswith("/preview-update"):
+                return httpx.Response(200, json={"strategy": {}, "validation": {}, "diff": {}, "estimatedImpact": {}})
+            return httpx.Response(200, json={"summary": "ok", "rationale": [], "confidence": 1, "inputs": {}, "decision": {}, "relatedEvents": []})
+
+        async def run():
+            client = self._async_client_with(handler)
+            try:
+                await client.get_strategy_health("strategy/id")
+                await client.validate_strategy_blocks("strategy/id", {"triggers": []})
+                await client.list_strategy_block_types()
+                await client.get_block_schema("special type/name")
+                await client.preview_strategy_update("strategy/id", {"tickMs": 5000})
+                await client.explain_strategy_decision("strategy/id", {"decisionId": "d-1"})
+            finally:
+                await client.close()
+
+        asyncio.run(run())
+
+        assert seen == [
+            ("GET", "/api/v1/strategies/strategy%2Fid/health"),
+            ("POST", "/api/v1/strategies/strategy%2Fid/validate-blocks"),
+            ("GET", "/api/v1/strategy-blocks"),
+            ("GET", "/api/v1/strategy-blocks/special%20type%2Fname"),
+            ("POST", "/api/v1/strategies/strategy%2Fid/preview-update"),
+            ("POST", "/api/v1/strategies/strategy%2Fid/explain"),
         ]
 
 


### PR DESCRIPTION
## Summary
- add sync/async Python SDK methods for strategy validation/operator endpoints from #297
- wire typed parsing for strategy health, block validation, block schemas, update previews, and decision explanations
- document the new strategy methods in README and CHANGELOG

## Verification
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_client.py::TestStrategyHealthAndValidationEndpoints -q`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_client.py -q`
- `git diff --check`
- `npx gitnexus detect-changes --repo "$PWD"`

Closes #297