### PR TITLE
fix: normalize copy config target wallet

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -3082,7 +3082,7 @@ class PolyforgeClient:
         Returns:
             The created :class:`CopyConfig`.
         """
-        body: dict[str, Any] = {"targetWallet": target_wallet}
+        body: dict[str, Any] = {"targetWallet": target_wallet.lower()}
         if mode is not None:
             body["mode"] = mode
         if size_value is not None:
@@ -6571,7 +6571,7 @@ class AsyncPolyforgeClient:
         price_offset: float | None = None,
     ) -> CopyConfig:
         """Create a new copy-trading configuration."""
-        body: dict[str, Any] = {"targetWallet": target_wallet}
+        body: dict[str, Any] = {"targetWallet": target_wallet.lower()}
         if mode is not None:
             body["mode"] = mode
         if size_value is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8156,6 +8156,32 @@ class TestTradingCopyNumericValidation:
         assert json_body["priceOffset"] == "-0.5"
         client.close()
 
+    def test_create_copy_config_normalizes_target_wallet_to_lowercase(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._post = MagicMock(return_value={
+            "id": "copy-1",
+            "userId": "user-1",
+            "targetWallet": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            "mode": "PERCENTAGE",
+            "sizeValue": "10",
+            "maxExposure": "500",
+            "maxDailyLoss": "100",
+            "priceOffset": "0",
+            "status": "ACTIVE",
+            "totalCopied": 0,
+            "totalPnl": "0",
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+        client.create_copy_config("0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd")
+        assert (
+            client._post.call_args.kwargs["json"]["targetWallet"]
+            == "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        )
+        client.close()
+
     def test_update_copy_config_sends_numeric_fields_as_strings(self):
         from unittest.mock import MagicMock
 
@@ -8469,6 +8495,36 @@ class TestTradingCopyNumericValidation:
                 )
             with pytest.raises(ValueError, match="Infinity"):
                 await client.update_copy_config("copy-1", price_offset="Infinity")  # type: ignore[arg-type]
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_create_copy_config_normalizes_target_wallet_to_lowercase(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            client._post = AsyncMock(return_value={
+                "id": "copy-1",
+                "userId": "user-1",
+                "targetWallet": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "mode": "PERCENTAGE",
+                "sizeValue": "10",
+                "maxExposure": "500",
+                "maxDailyLoss": "100",
+                "priceOffset": "0",
+                "status": "ACTIVE",
+                "totalCopied": 0,
+                "totalPnl": "0",
+                "createdAt": "2026-04-29T00:00:00Z",
+                "updatedAt": "2026-04-29T00:00:00Z",
+            })
+            await client.create_copy_config("0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd")
+            assert (
+                client._post.call_args.kwargs["json"]["targetWallet"]
+                == "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            )
             await client.close()
 
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Normalize sync and async create_copy_config target_wallet values to lowercase before POST /api/v1/copy
- Add sync and async regression tests for mixed-case target_wallet handling

Fixes F4CTE/polyforge-sdk-python#286.
Paperclip: POLA-14750, POLA-14746.

## Verification
- timeout 300 uv run --extra dev pytest tests/test_client.py -k 'create_copy_config or update_copy_config or async_copy_and_whale_paths_validate_before_awaiting'
- npx gitnexus detect-changes --repo polyforge-sdk-python (LOW risk, no affected processes)

Note: post-commit npx gitnexus analyze emitted a segmentation fault after analysis output; generated metadata churn was not committed.