### PR TITLE
fix(sdk-python): reject unknown marketplace listing fields

### DIFF
--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -681,6 +681,11 @@ _MARKETPLACE_LISTING_KNOWN_KWARGS: frozenset[str] = frozenset({
 
 
 def _reject_unknown_marketplace_listing_fields(fields: dict[str, Any]) -> None:
+    if "price" in fields:
+        if "priceUsdc" in fields:
+            raise ValueError("update_marketplace_listing accepts either price or priceUsdc, not both")
+        _validate_financial_param("price", fields["price"])
+        fields["priceUsdc"] = fields.pop("price")
     unknown = {key for key in fields if key not in _MARKETPLACE_LISTING_KNOWN_KWARGS}
     if unknown:
         raise ValueError(

--- a/src/polyforge/client.py
+++ b/src/polyforge/client.py
@@ -675,6 +675,19 @@ _COPY_CONFIG_KNOWN_KWARGS: frozenset[str] = frozenset({
     "mode", "sizeValue", "maxExposure", "maxDailyLoss", "priceOffset",
 })
 
+_MARKETPLACE_LISTING_KNOWN_KWARGS: frozenset[str] = frozenset({
+    "title", "description", "priceUsdc", "tags", "status",
+})
+
+
+def _reject_unknown_marketplace_listing_fields(fields: dict[str, Any]) -> None:
+    unknown = {key for key in fields if key not in _MARKETPLACE_LISTING_KNOWN_KWARGS}
+    if unknown:
+        raise ValueError(
+            "update_marketplace_listing got unexpected keyword arguments: "
+            f"{', '.join(sorted(unknown))}"
+        )
+
 
 _BLOCKED_HOSTNAMES: set[str] = {
     "localhost",
@@ -2537,6 +2550,7 @@ class PolyforgeClient:
         Returns:
             The updated :class:`MarketplaceListing`.
         """
+        _reject_unknown_marketplace_listing_fields(kwargs)
         return _parse(
             MarketplaceListing,
             self._patch(f"/api/v1/marketplace/{_encode_path(listing_id)}", json=kwargs),
@@ -6163,6 +6177,7 @@ class AsyncPolyforgeClient:
 
     async def update_marketplace_listing(self, listing_id: str, **kwargs: Any) -> MarketplaceListing:
         """Update an existing marketplace listing."""
+        _reject_unknown_marketplace_listing_fields(kwargs)
         return _parse(
             MarketplaceListing,
             await self._patch(f"/api/v1/marketplace/{_encode_path(listing_id)}", json=kwargs),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4545,6 +4545,29 @@ class TestMarketplaceSellerCrud:
             client.update_marketplace_listing("listing-1", typoField=5)
         client.close()
 
+    def test_sync_update_marketplace_listing_accepts_price_alias(self):
+        from unittest.mock import MagicMock
+
+        client = PolyforgeClient(api_key="test")
+        client._patch = MagicMock(return_value={
+            "id": "listing-1",
+            "strategyId": "strategy-1",
+            "sellerId": "seller-1",
+            "title": "Listing",
+            "description": None,
+            "priceUsdc": "9.99",
+            "tags": [],
+            "status": "ACTIVE",
+            "ratingAvg": 0,
+            "ratingCount": 0,
+            "purchaseCount": 0,
+            "createdAt": "2026-04-29T00:00:00Z",
+            "updatedAt": "2026-04-29T00:00:00Z",
+        })
+        client.update_marketplace_listing("listing-1", price=9.99)
+        assert client._patch.call_args.kwargs["json"] == {"priceUsdc": 9.99}
+        client.close()
+
     def test_async_update_marketplace_listing_rejects_unknown_kwargs(self):
         import asyncio
 
@@ -4552,6 +4575,33 @@ class TestMarketplaceSellerCrud:
             client = AsyncPolyforgeClient(api_key="test")
             with pytest.raises(ValueError, match="unexpected keyword"):
                 await client.update_marketplace_listing("listing-1", typoField=5)
+            await client.close()
+
+        asyncio.run(_run())
+
+    def test_async_update_marketplace_listing_accepts_price_alias(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            client._patch = AsyncMock(return_value={
+                "id": "listing-1",
+                "strategyId": "strategy-1",
+                "sellerId": "seller-1",
+                "title": "Listing",
+                "description": None,
+                "priceUsdc": "9.99",
+                "tags": [],
+                "status": "ACTIVE",
+                "ratingAvg": 0,
+                "ratingCount": 0,
+                "purchaseCount": 0,
+                "createdAt": "2026-04-29T00:00:00Z",
+                "updatedAt": "2026-04-29T00:00:00Z",
+            })
+            await client.update_marketplace_listing("listing-1", price=9.99)
+            assert client._patch.call_args.kwargs["json"] == {"priceUsdc": 9.99}
             await client.close()
 
         asyncio.run(_run())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4539,6 +4539,23 @@ class TestMarketplaceSellerCrud:
         assert "_patch" in source
         assert "_encode_path" in source
 
+    def test_sync_update_marketplace_listing_rejects_unknown_kwargs(self):
+        client = PolyforgeClient(api_key="test")
+        with pytest.raises(ValueError, match="unexpected keyword"):
+            client.update_marketplace_listing("listing-1", typoField=5)
+        client.close()
+
+    def test_async_update_marketplace_listing_rejects_unknown_kwargs(self):
+        import asyncio
+
+        async def _run():
+            client = AsyncPolyforgeClient(api_key="test")
+            with pytest.raises(ValueError, match="unexpected keyword"):
+                await client.update_marketplace_listing("listing-1", typoField=5)
+            await client.close()
+
+        asyncio.run(_run())
+
     # -- rate_marketplace_listing --
 
     def test_sync_rate_marketplace_listing_exists(self):


### PR DESCRIPTION
## Summary

- reject unknown keyword arguments in sync `update_marketplace_listing` before PATCH
- apply the same unknown-field guard in async `update_marketplace_listing`
- add focused sync and async tests for unexpected marketplace listing fields

Paperclip: POLA-19657

## Verification

- `uv run --extra dev python -m pytest tests/test_client.py -q` -> 1173 passed, 1 existing deprecation warning
- `uv run --extra dev pyright` -> 0 errors
- `git diff --check origin/master...HEAD`
