### PR TITLE
docs: align Python SDK links with Polyforge-labs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,8 @@ The shared ADR consumes:
 
 - Shared SDK decisions use `SDK-ADR-*` and remain logically synchronized across TypeScript, Python and Rust repositories.
 - Python-only implementation decisions use `PY-ADR-*`.
-- Core runtime contracts are owned by `F4CTE/PolyForge-core`.
-- Cloud/control-plane contracts are owned by `F4CTE/PolyForge`.
+- Core runtime contracts are owned by `Polyforge-labs/PolyForge-core`.
+- Cloud/control-plane contracts are owned by `Polyforge-labs/PolyForge`.
 
 ## Parity rule
 


### PR DESCRIPTION
Update the Python SDK documentation links to the Polyforge-labs organization. Verification: git diff --check.