### PR TITLE
docs: update copyright owner and package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 PolyForge Labs
+   Copyright 2026 Oryon Technologies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 PolyForge SDK Python
-Copyright 2026 PolyForge Labs
+Copyright 2026 Oryon Technologies
 
 Licensed under the Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Polyforge Python SDK
+# PolyForge Python SDK
 
-Typed Python client for the [Polyforge](https://polyforge.io) trading platform REST API. Provides both synchronous and asynchronous interfaces powered by [httpx](https://www.python-httpx.org/).
+Typed Python client for the [PolyForge](https://polyforge.app) REST API, compatible with self-hosted and PolyForge Platform deployments. Provides both synchronous and asynchronous interfaces powered by [httpx](https://www.python-httpx.org/).
 
 ## Installation
 
@@ -343,4 +343,6 @@ pytest tests/
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE) for details.
+Copyright © 2026 Oryon Technologies.
+
+Licensed under Apache 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 keywords = ["polyforge", "trading", "api", "sdk", "crypto", "defi"]
 authors = [
-    { name = "Polyforge", email = "dev@polyforge.io" },
+    { name = "Oryon Technologies", email = "dev@polyforge.app" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -40,10 +40,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/polyforge/polyforge-sdk-python"
-Documentation = "https://docs.polyforge.io/sdk/python"
-Repository = "https://github.com/polyforge/polyforge-sdk-python"
-Issues = "https://github.com/polyforge/polyforge-sdk-python/issues"
+Homepage = "https://polyforge.app"
+Documentation = "https://polyforge.app/docs"
+Repository = "https://github.com/Polyforge-labs/PolyForge-sdk-python"
+Issues = "https://github.com/Polyforge-labs/PolyForge-sdk-python/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/polyforge"]


### PR DESCRIPTION
## Summary

- update copyright ownership from PolyForge Labs to Oryon Technologies
- replace stale polyforge.io and personal-account repository links
- clarify compatibility with self-hosted PolyForge and PolyForge Platform deployments
- retain the existing Apache 2.0 SDK licence

## Verification

- isolated development environment installed with `pip install -e ".[dev]"`
- `pytest` — 1,185 tests passed
- `pyright` — 0 errors and 0 warnings
- `git diff --check` passed
- GitNexus staged analysis: low risk, 0 affected execution flows